### PR TITLE
DELIA-66037 - Trace and Ping ERROR_TIMEOUT response

### DIFF
--- a/LegacyPlugin_NetworkAPIs.cpp
+++ b/LegacyPlugin_NetworkAPIs.cpp
@@ -27,6 +27,7 @@ using namespace WPEFramework::Plugin;
 #define API_VERSION_NUMBER_PATCH 0
 #define NETWORK_MANAGER_CALLSIGN    "org.rdk.NetworkManager.1"
 #define SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS 500
+#define DEFAULT_PING_PACKETS 15
 
 #define LOGINFOMETHOD() { string json; parameters.ToString(json); NMLOG_TRACE("Legacy params=%s", json.c_str() ); }
 #define LOGTRACEMETHODFIN() { string json; response.ToString(json); NMLOG_TRACE("Legacy response=%s", json.c_str() ); }
@@ -577,12 +578,15 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 tmpParameters["ipversion"] = "IPv4";
             else if (inet_pton(AF_INET6, endpoint.c_str(), &ipv6address) > 0)
                 tmpParameters["ipversion"] = "IPv6";
-            
-            tmpParameters["noOfRequest"] = parameters["packets"];
+
+            if (parameters.HasLabel("packets"))
+                tmpParameters["noOfRequest"] = parameters["packets"];
+            else
+                tmpParameters["noOfRequest"] = DEFAULT_PING_PACKETS;
             tmpParameters["endpoint"] = parameters["endpoint"];
             tmpParameters["timeout"] = 5;
             tmpParameters["guid"] = parameters["guid"];
-            
+
             if (m_networkmanager)
                 rc = m_networkmanager->Invoke<JsonObject, JsonObject>(15000, _T("Ping"), tmpParameters, response);
             else

--- a/docs/NetworkManagerPlugin.md
+++ b/docs/NetworkManagerPlugin.md
@@ -964,7 +964,7 @@ No Events
 | params | object |  |
 | params.endpoint | string | The host name or IP address |
 | params.ipversion | string | either IPv4 or IPv6 |
-| params.noOfRequest | integer | The number of packets to send. Default is 15 |
+| params.noOfRequest | integer | <sup>*(optional)*</sup> The number of packets to send. Default is 3 |
 | params.timeout | integer | Timeout |
 | params.guid | string | The globally unique identifier |
 
@@ -1042,7 +1042,7 @@ No Events
 | params | object |  |
 | params.ipversion| string  | <sup>*(optional)*</sup> The host name or IP address |
 | params.endpoint | string  | The host name or IP address |
-| params.packets  | integer | <sup>*(optional)*</sup> The number of packets to send. Default is 10 |
+| params.packets  | integer | <sup>*(optional)*</sup> The number of packets to send. Default is 5 |
 | params.guid     | string  | <sup>*(optional)*</sup> The globally unique identifier |
 
 ### Result
@@ -1065,7 +1065,7 @@ No Events
     "method": "org.rdk.NetworkManager.Trace",
     "params": {
         "endpoint": "45.57.221.20",
-        "packets": 10
+        "packets": 5
     }
 }
 ```


### PR DESCRIPTION
Reason for change: Changed the default packet size of trace in the networkmanagerplugin.md to 5 and also added default packet size for ping in Legacynetworkplugin.cpp
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>