### PR TITLE
DELIA-66318 : Update NetworkManager Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ set(PLUGIN_LEGACY_DEPRECATED_WIFI    ${NAMESPACE}WiFiManager)
 find_package(${NAMESPACE}Core REQUIRED)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(CURL)
+
+set(PLUGIN_NETWORKMANAGER_STARTUPORDER "55" CACHE STRING "To configure startup order of Unified NetworkManager plugin")
+set(PLUGIN_LEGACY_NW_STARTUPORDER "56" CACHE STRING "To configure startup order of Legacy Network plugin")
+set(PLUGIN_LEGACY_WIFI_STARTUPORDER "56" CACHE STRING "To configure startup order of Legacy WiFi plugin")
+
 if(ENABLE_GNOME_NETWORKMANAGER)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(LIBNM REQUIRED libnm)

--- a/LegacyPlugin_NetworkAPIs.conf.in
+++ b/LegacyPlugin_NetworkAPIs.conf.in
@@ -1,3 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.Network"
 autostart = "true"
+startuporder = "@PLUGIN_LEGACY_NW_STARTUPORDER@"

--- a/LegacyPlugin_NetworkAPIs.config
+++ b/LegacyPlugin_NetworkAPIs.config
@@ -1,3 +1,4 @@
 set (autostart true)
 set (preconditions Platform)
 set (callsign "org.rdk.Network")
+set (startuporder ${PLUGIN_LEGACY_NW_STARTUPORDER})

--- a/LegacyPlugin_NetworkAPIs.cpp
+++ b/LegacyPlugin_NetworkAPIs.cpp
@@ -152,9 +152,9 @@ namespace WPEFramework
             }
         
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            m_networkmanager = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(_T(NETWORK_MANAGER_CALLSIGN), _T(NETWORK_MANAGER_CALLSIGN), false, query);
+            m_networkmanager = make_shared<WPEFramework::JSONRPC::SmartLinkType<WPEFramework::Core::JSON::IElement> >(_T(NETWORK_MANAGER_CALLSIGN), _T("org.rdk.Network"), query);
 
-            doTheSubscriptions();
+            subscribeToEvents();
             return string();
         }
 
@@ -787,21 +787,6 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
         }
 
         /** Private */
-        void Network::doTheSubscriptions(void)
-        {
-            uint32_t result = Core::ERROR_ASYNC_FAILED;
-            Core::Event event(false, true);
-            Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create([&]() {
-                NMLOG_INFO ("Start Subscription %s", __FUNCTION__);
-                subscribeToEvents();
-                m_timer.start(SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS);
-                event.SetEvent();
-            })));
-            event.Lock();
-
-            return;
-        }
-
         void Network::subscribeToEvents(void)
         {
             uint32_t errCode = Core::ERROR_GENERAL;

--- a/LegacyPlugin_NetworkAPIs.h
+++ b/LegacyPlugin_NetworkAPIs.h
@@ -31,7 +31,6 @@ namespace WPEFramework {
             void registerLegacyMethods(void);
             void unregisterLegacyMethods(void);
             void subscribeToEvents(void);
-            void doTheSubscriptions(void);
             static std::string getInterfaceMapping(const std::string &interface);
             void activatePrimaryPlugin();
 
@@ -83,7 +82,7 @@ namespace WPEFramework {
 
         private:
             PluginHost::IShell* m_service;
-            std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
+            std::shared_ptr<WPEFramework::JSONRPC::SmartLinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
             string m_defaultInterface;
             NetworkManagerTimer m_timer;
 

--- a/LegacyPlugin_WiFiManagerAPIs.conf.in
+++ b/LegacyPlugin_WiFiManagerAPIs.conf.in
@@ -1,3 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.Wifi"
 autostart = "true"
+startuporder = "@PLUGIN_LEGACY_WIFI_STARTUPORDER@"

--- a/LegacyPlugin_WiFiManagerAPIs.config
+++ b/LegacyPlugin_WiFiManagerAPIs.config
@@ -1,3 +1,4 @@
 set (autostart true)
 set (preconditions Platform)
 set (callsign "org.rdk.Wifi")
+set (startuporder ${PLUGIN_LEGACY_WIFI_STARTUPORDER})

--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -148,9 +148,9 @@ namespace WPEFramework
             }
         
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            m_networkmanager = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(_T(NETWORK_MANAGER_CALLSIGN), _T(NETWORK_MANAGER_CALLSIGN), false, query);
+            m_networkmanager = make_shared<WPEFramework::JSONRPC::SmartLinkType<WPEFramework::Core::JSON::IElement> >(_T(NETWORK_MANAGER_CALLSIGN), _T("org.rdk.Wifi"), query);
 
-            doTheSubscriptions();
+            subscribeToEvents();
             return string();
         }
 
@@ -504,21 +504,6 @@ namespace WPEFramework
         }
 
         /** Private */
-        void WiFiManager::doTheSubscriptions(void)
-        {
-            uint32_t result = Core::ERROR_ASYNC_FAILED;
-            Core::Event event(false, true);
-            Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create([&]() {
-                NMLOG_INFO ("Start Subscription %s", __FUNCTION__);
-                subscribeToEvents();
-                m_timer.start(SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS);
-                event.SetEvent();
-            })));
-            event.Lock();
-
-            return;
-        }
-
         void WiFiManager::subscribeToEvents(void)
         {
             uint32_t errCode = Core::ERROR_GENERAL;

--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -99,14 +99,13 @@ namespace WPEFramework {
             void registerLegacyMethods(void);
             void unregisterLegacyMethods(void);
             void subscribeToEvents(void);
-            void doTheSubscriptions(void);
             static std::string getInterfaceMapping(const std::string &interface);
             static bool ErrorCodeMapping(const uint32_t ipvalue , uint32_t &opvalue);
             void activatePrimaryPlugin();
 
         private:
             PluginHost::IShell* m_service;
-            std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
+            std::shared_ptr<WPEFramework::JSONRPC::SmartLinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
             NetworkManagerTimer m_timer;
             bool m_subsWiFiStateChange;
             bool m_subsAvailableSSIDs;

--- a/NetworkManager.conf.in
+++ b/NetworkManager.conf.in
@@ -1,5 +1,5 @@
-autostart = "true"
 callsign= "org.rdk.NetworkManager"
+startuporder = "@PLUGIN_NETWORKMANAGER_STARTUPORDER@"
 
 process= JSON()
 process.add("outofprocess", "true")

--- a/NetworkManager.config
+++ b/NetworkManager.config
@@ -1,5 +1,5 @@
-set(autostart true)
 set(callsign "org.rdk.NetworkManager")
+set (startuporder ${PLUGIN_NETWORKMANAGER_STARTUPORDER})
 
 map()
    key(root)

--- a/NetworkManager.h
+++ b/NetworkManager.h
@@ -247,7 +247,7 @@ namespace WPEFramework
             // find the real implementation
             // This allows other components to call QueryInterface<INetworkManager>() and
             // receive the actual implementation (which could be in-process or out-of-process)
-            INTERFACE_AGGREGATE(Exchange::INetworkManager, _NetworkManager)
+            INTERFACE_AGGREGATE(Exchange::INetworkManager, _networkManager)
             END_INTERFACE_MAP
 
             /*
@@ -311,7 +311,8 @@ namespace WPEFramework
         private:
             uint32_t _connectionId;
             PluginHost::IShell *_service;
-            Exchange::INetworkManager *_NetworkManager;
+            PluginHost::IPlugin* _networkManagerImpl;
+            Exchange::INetworkManager *_networkManager;
             Core::Sink<Notification> _notification;
             string m_publicIPAddress;
             string m_defaultInterface;

--- a/NetworkManagerJsonRpc.cpp
+++ b/NetworkManagerJsonRpc.cpp
@@ -125,8 +125,8 @@ namespace WPEFramework
                 NetworkManagerLogger::SetLevel(level);
 
                 const Exchange::INetworkManager::NMLogging log = static_cast <Exchange::INetworkManager::NMLogging> (level);
-                if (_NetworkManager)
-                    rc = _NetworkManager->SetLogLevel(log);
+                if (_networkManager)
+                    rc = _networkManager->SetLogLevel(log);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
             }
@@ -144,8 +144,8 @@ namespace WPEFramework
 
             uint32_t rc = Core::ERROR_GENERAL;
             Exchange::INetworkManager::IInterfaceDetailsIterator* interfaces = NULL;
-            if (_NetworkManager)
-                rc = _NetworkManager->GetAvailableInterfaces(interfaces);
+            if (_networkManager)
+                rc = _networkManager->GetAvailableInterfaces(interfaces);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -179,8 +179,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
             string interface;
-            if (_NetworkManager)
-                rc = _NetworkManager->GetPrimaryInterface(interface);
+            if (_networkManager)
+                rc = _networkManager->GetPrimaryInterface(interface);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -206,8 +206,8 @@ namespace WPEFramework
                 return rc;
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->SetPrimaryInterface(interface);
+            if (_networkManager)
+                rc = _networkManager->SetPrimaryInterface(interface);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -232,8 +232,8 @@ namespace WPEFramework
                 return rc;
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->SetInterfaceState(interface, enabled);
+            if (_networkManager)
+                rc = _networkManager->SetInterfaceState(interface, enabled);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -258,8 +258,8 @@ namespace WPEFramework
                 return rc;
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetInterfaceState(interface, isEnabled);
+            if (_networkManager)
+                rc = _networkManager->GetInterfaceState(interface, isEnabled);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -291,8 +291,8 @@ namespace WPEFramework
                 return rc;
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetIPSettings(interface, ipversion, result);
+            if (_networkManager)
+                rc = _networkManager->GetIPSettings(interface, ipversion, result);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -349,8 +349,8 @@ namespace WPEFramework
                 result.m_secondaryDns   = parameters["secondarydns"];
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->SetIPSettings(interface, ipversion, result);
+            if (_networkManager)
+                rc = _networkManager->SetIPSettings(interface, ipversion, result);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -371,8 +371,8 @@ namespace WPEFramework
             uint32_t bindTimeout;
             uint32_t cacheTimeout;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetStunEndpoint(endPoint, port, bindTimeout, cacheTimeout);
+            if (_networkManager)
+                rc = _networkManager->GetStunEndpoint(endPoint, port, bindTimeout, cacheTimeout);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -397,8 +397,8 @@ namespace WPEFramework
             uint32_t bindTimeout = parameters["bindTimeout"].Number();
             uint32_t cacheTimeout = parameters["cacheTimeout"].Number();
 
-            if (_NetworkManager)
-                rc = _NetworkManager->SetStunEndpoint(endPoint, port, bindTimeout, cacheTimeout);
+            if (_networkManager)
+                rc = _networkManager->SetStunEndpoint(endPoint, port, bindTimeout, cacheTimeout);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -417,8 +417,8 @@ namespace WPEFramework
             Exchange::INetworkManager::IStringIterator* endpoints = NULL;
             
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetConnectivityTestEndpoints(endpoints);
+            if (_networkManager)
+                rc = _networkManager->GetConnectivityTestEndpoints(endpoints);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -470,8 +470,8 @@ namespace WPEFramework
             }
             endpointsIter = (Core::Service<RPC::StringIterator>::Create<RPC::IStringIterator>(endpoints));
 
-            if (_NetworkManager)
-                rc = _NetworkManager->SetConnectivityTestEndpoints(endpointsIter);
+            if (_networkManager)
+                rc = _networkManager->SetConnectivityTestEndpoints(endpointsIter);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -495,8 +495,8 @@ namespace WPEFramework
             Exchange::INetworkManager::InternetStatus result;
             
 
-            if (_NetworkManager)
-                rc = _NetworkManager->IsConnectedToInternet(ipversion, result);
+            if (_networkManager)
+                rc = _networkManager->IsConnectedToInternet(ipversion, result);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -533,8 +533,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
             string endPoint;
-            if (_NetworkManager)
-                rc = _NetworkManager->GetCaptivePortalURI(endPoint);
+            if (_networkManager)
+                rc = _networkManager->GetCaptivePortalURI(endPoint);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -554,8 +554,8 @@ namespace WPEFramework
             uint32_t interval = parameters["interval"].Number();
 
             NMLOG_TRACE("connectivity interval = %d", interval);
-            if (_NetworkManager)
-                rc = _NetworkManager->StartConnectivityMonitoring(interval);
+            if (_networkManager)
+                rc = _networkManager->StartConnectivityMonitoring(interval);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -572,8 +572,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->StopConnectivityMonitoring();
+            if (_networkManager)
+                rc = _networkManager->StopConnectivityMonitoring();
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -601,8 +601,8 @@ namespace WPEFramework
             }
             else
             {
-                if (_NetworkManager)
-                    rc = _NetworkManager->GetPublicIP(ipversion, ipAddress);
+                if (_networkManager)
+                    rc = _networkManager->GetPublicIP(ipversion, ipAddress);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
             }
@@ -675,8 +675,8 @@ namespace WPEFramework
                 if (parameters.HasLabel("guid"))
                     guid = parameters["guid"].String();
 
-                if (_NetworkManager)
-                    rc = _NetworkManager->Ping(ipversion, endpoint, noOfRequest, timeOutInSeconds, guid, result);
+                if (_networkManager)
+                    rc = _networkManager->Ping(ipversion, endpoint, noOfRequest, timeOutInSeconds, guid, result);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
             }
@@ -701,8 +701,8 @@ namespace WPEFramework
             const uint32_t noOfRequest  = parameters["packets"].Number();
             const string guid           = parameters["guid"].String();
 
-            if (_NetworkManager)
-                rc = _NetworkManager->Trace(ipversion, endpoint, noOfRequest, guid, result);
+            if (_networkManager)
+                rc = _networkManager->Trace(ipversion, endpoint, noOfRequest, guid, result);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -723,8 +723,8 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
             const Exchange::INetworkManager::WiFiFrequency frequency = static_cast <Exchange::INetworkManager::WiFiFrequency> (parameters["frequency"].Number());
 
-            if (_NetworkManager)
-                rc = _NetworkManager->StartWiFiScan(frequency);
+            if (_networkManager)
+                rc = _networkManager->StartWiFiScan(frequency);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -741,8 +741,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->StopWiFiScan();
+            if (_networkManager)
+                rc = _networkManager->StopWiFiScan();
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -762,8 +762,8 @@ namespace WPEFramework
             JsonArray ssids;
             ::WPEFramework::RPC::IIteratorType<string, RPC::ID_STRINGITERATOR>* _ssids{};
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetKnownSSIDs(_ssids);
+            if (_networkManager)
+                rc = _networkManager->GetKnownSSIDs(_ssids);
 
             if (Core::ERROR_NONE == rc)
             {
@@ -797,8 +797,8 @@ namespace WPEFramework
                 ssid.m_passphrase      = parameters["passphrase"].String();
                 ssid.m_securityMode    = static_cast <Exchange::INetworkManager::WIFISecurityMode> (parameters["securityMode"].Number());
 
-                if (_NetworkManager)
-                    rc = _NetworkManager->AddToKnownSSIDs(ssid);
+                if (_networkManager)
+                    rc = _networkManager->AddToKnownSSIDs(ssid);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
             }
@@ -820,8 +820,8 @@ namespace WPEFramework
             if (parameters.HasLabel("ssid"))
             {
                 ssid = parameters["ssid"].String();
-                if (_NetworkManager)
-                    rc = _NetworkManager->RemoveKnownSSID(ssid);
+                if (_networkManager)
+                    rc = _networkManager->RemoveKnownSSID(ssid);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
             }
@@ -861,8 +861,8 @@ namespace WPEFramework
                 ssid.m_persistSSIDInfo   = parameters["persistSSIDInfo"].Boolean();
             else
                 ssid.m_persistSSIDInfo   = true;
-            if (_NetworkManager)
-                rc = _NetworkManager->WiFiConnect(ssid);
+            if (_networkManager)
+                rc = _networkManager->WiFiConnect(ssid);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -879,8 +879,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->WiFiDisconnect();
+            if (_networkManager)
+                rc = _networkManager->WiFiDisconnect();
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -898,8 +898,8 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
             Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetConnectedSSID(ssidInfo);
+            if (_networkManager)
+                rc = _networkManager->GetConnectedSSID(ssidInfo);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -937,8 +937,8 @@ namespace WPEFramework
                 wps_pin = parameters["wps_pin"].String();
             }
 
-            if (_NetworkManager)
-                rc = _NetworkManager->StartWPS(method, wps_pin);
+            if (_networkManager)
+                rc = _networkManager->StartWPS(method, wps_pin);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -955,8 +955,8 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->StopWPS();
+            if (_networkManager)
+                rc = _networkManager->StopWPS();
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -974,8 +974,8 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
 
             LOGINFOMETHOD();
-            if (_NetworkManager)
-                rc = _NetworkManager->GetWifiState(state);
+            if (_networkManager)
+                rc = _networkManager->GetWifiState(state);
             else
                 rc = Core::ERROR_UNAVAILABLE;
             if (Core::ERROR_NONE == rc)
@@ -995,8 +995,8 @@ namespace WPEFramework
             string signalStrength{};
             Exchange::INetworkManager::WiFiSignalQuality quality;
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetWiFiSignalStrength(ssid, signalStrength, quality);
+            if (_networkManager)
+                rc = _networkManager->GetWiFiSignalStrength(ssid, signalStrength, quality);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
@@ -1017,8 +1017,8 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
             Exchange::INetworkManager::ISecurityModeIterator* securityModes{};
 
-            if (_NetworkManager)
-                rc = _NetworkManager->GetSupportedSecurityModes(securityModes);
+            if (_networkManager)
+                rc = _networkManager->GetSupportedSecurityModes(securityModes);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 


### PR DESCRIPTION
Reason for change:
- Use of SmartLinkType
- Use IPluginImpl to release ComRPC instance upon Deactivate
- Setup Startup Order to ensure NetworkManager is up before legacy plugins are activated

Test Procedure: Full Networking Verification
Risks: Low
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>