### PR TITLE
XIONE-15762 - [RDKE] [Xione]- Jumpserver access fails

### DIFF
--- a/NetworkManagerJsonRpc.cpp
+++ b/NetworkManagerJsonRpc.cpp
@@ -285,7 +285,7 @@ namespace WPEFramework
             if (parameters.HasLabel("ipversion"))
                 ipversion = parameters["ipversion"].String();
 
-            if ("wlan0" != interface && "eth0" != interface)
+            if ("wlan0" != interface && "eth0" != interface && "" != interface)
             {
                 rc = Core::ERROR_BAD_REQUEST;
                 return rc;


### PR DESCRIPTION
Reason for change: In the input of getIPsettings, NULL is being passed for interface.
Allowing null interface also
Test Procedure: NA
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>