### PR TITLE
DELIA-66411 : Retry when subscription to an event failed

### DIFF
--- a/LegacyPlugin_NetworkAPIs.cpp
+++ b/LegacyPlugin_NetworkAPIs.cpp
@@ -864,6 +864,11 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 m_timer.stop();
                 NMLOG_INFO("subscriber timer stoped");
             }
+            else
+            {
+                m_timer.start(SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS);
+                NMLOG_INFO("subscriber timer started");
+            }
         }
 
         string Network::getInterfaceMapping(const string & interface)

--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -544,6 +544,11 @@ namespace WPEFramework
                 m_timer.stop();
                 NMLOG_INFO("subscriber timer stoped");
             }
+            else
+            {
+                m_timer.start(SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS);
+                NMLOG_INFO("subscriber timer started");
+            }
         }
 
          bool WiFiManager::ErrorCodeMapping(const uint32_t ipvalue, uint32_t &opvalue)


### PR DESCRIPTION
Reason for change: In the reported ticket, it is noticed that WiFi Plugin failed to subscribe `onAvailableSSIDs` event but didnt retry. So when scan is called by application, the scan was success but it never posted any update as it never received `onAvailableSSIDs` event from unified networkmanager plugin Test Procedure: As per DELIA-66411
Risks: Medium
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>