### PR TITLE
DELIA-66721 : Fixed the empty interface being returned in GetIPSettings

### DIFF
--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -72,8 +72,6 @@ namespace WPEFramework {
             uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response);
             uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response);
             uint32_t isPaired(const JsonObject& parameters, JsonObject& response);
-            uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
-            uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
             //End methods
 

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -855,7 +855,17 @@ namespace WPEFramework
                 }
 
                 /* Return the default interface information */
-                interface = string(interface);
+                if (interface.empty())
+                {
+                    string tmpInterface = string(iarmData.interface);
+                    if ("ETHERNET" == tmpInterface)
+                        interface = "eth0";
+                    else if ("WIFI" == tmpInterface)
+                        interface = "wlan0";
+                    else
+                        rc = Core::ERROR_BAD_REQUEST;
+                }
+
                 rc = Core::ERROR_NONE;
             }
             else


### PR DESCRIPTION
Reason for change: Fixed the empty interface being returned in GetIPSettings
Test Procedure: as per DELIA-66721
Risks: Low
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>