### PR TITLE
RDKEMW-229 : Check the empty interface & ipversion input

### DIFF
--- a/NetworkManagerJsonRpc.cpp
+++ b/NetworkManagerJsonRpc.cpp
@@ -290,8 +290,14 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
             Exchange::INetworkManager::IPAddress address{};
 
-            string interface = parameters["interface"].String();
-            string ipversion = parameters["ipversion"].String();
+            string interface{};
+            string ipversion{};
+
+            if (parameters.HasLabel("interface"))
+                interface = parameters["interface"].String();
+
+            if (parameters.HasLabel("ipversion"))
+                ipversion = parameters["ipversion"].String();
 
             if (_networkManager)
                 rc = _networkManager->GetIPSettings(interface, ipversion, address);


### PR DESCRIPTION
Reason for change: Check the empty interface & ipversion input
Test Procedure: Call org.rdk.NetworkManager.GetIPSettings with no input param
Risks: Medium
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>