### PR TITLE
DELIA-66893 - GetInterfaceState is not working

### DIFF
--- a/NetworkManagerJsonRpc.cpp
+++ b/NetworkManagerJsonRpc.cpp
@@ -271,7 +271,7 @@ namespace WPEFramework
                 if ("wlan0" != interface && "eth0" != interface)
                     rc = Core::ERROR_BAD_REQUEST;
                 else if (_networkManager)
-                    rc = _networkManager->SetInterfaceState(interface, enabled);
+                    rc = _networkManager->GetInterfaceState(interface, enabled);
                 else
                     rc = Core::ERROR_UNAVAILABLE;
 


### PR DESCRIPTION
Reason for change: GetInterfaceState is using the SetInterfaceState networkmanager implementation call instead of GetInterfaceState call. Modified the same.
Test Procedure: Check with curl commands
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>