### PR TITLE
DELIA-66920 - GetWiFiSignalStrength is not return actual strength

### DIFF
--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -1256,6 +1256,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 if (signalStrengthOut == 0)
                 {
                     quality = WIFI_SIGNAL_DISCONNECTED;
+                    signalStrength = "0";
                 }
                 else if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
                 {

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -1256,27 +1256,22 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 if (signalStrengthOut == 0)
                 {
                     quality = WIFI_SIGNAL_DISCONNECTED;
-                    signalStrength = "0";
                 }
                 else if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
                 {
                     quality = WIFI_SIGNAL_EXCELLENT;
-                    signalStrength = "100";
                 }
                 else if (signalStrengthOut >= signalStrengthThresholdGood && signalStrengthOut < signalStrengthThresholdExcellent)
                 {
                     quality = WIFI_SIGNAL_GOOD;
-                    signalStrength = "75";
                 }
                 else if (signalStrengthOut >= signalStrengthThresholdFair && signalStrengthOut < signalStrengthThresholdGood)
                 {
                     quality = WIFI_SIGNAL_FAIR;
-                    signalStrength = "50";
                 }
                 else
                 {
                     quality = WIFI_SIGNAL_WEAK;
-                    signalStrength = "25";
                 }
 
                 NMLOG_INFO ("GetWiFiSignalStrength success");


### PR DESCRIPTION
Reason for change: Removed the internal mapping and returning the actual strength value
Test Procedure: Check with curl command
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>