### PR TITLE
DELIA-67124 : Handle the JSON Subscribe Event

### DIFF
--- a/NetworkManager.h
+++ b/NetworkManager.h
@@ -132,6 +132,14 @@ namespace WPEFramework
             void Deinitialize(PluginHost::IShell *service) override;
             string Information() const override;
 
+            //override Subscribe from IDispatcher
+            uint32_t Subscribe(const uint32_t channel, const string& event, const string& designator) override
+            {
+                NMLOG_DEBUG("Subscription received for %s event from channelID (%u) with designator as %s", event.c_str(), channel, designator.c_str());
+                JSONRPC::Subscribe(channel, event, designator);
+                return Core::ERROR_NONE;
+            }
+
             // Do not allow copy/move constructors
             NetworkManager(const NetworkManager &) = delete;
             NetworkManager &operator=(const NetworkManager &) = delete;


### PR DESCRIPTION
DELIA-67124 : Handle the JSON Subscribe Event

Reason for change: The subscription request reached the NetworkManager and responded but due to the boot-up time no-cpu scenario, the success is NOT sent to consumer. So the consumer subscribes for the 2nd time, it returns already_exist error. It should be handled cleanly.
Test Procedure: As per DELIA-67124
Risks: Low
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>