### PR TITLE
RDK-55421 : Implementation of new API - org.rdk.Wifi.retrieveSSID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ set_target_properties(${MODULE_NAME} PROPERTIES
                                      CXX_STANDARD_REQUIRED YES
                                      FRAMEWORK FALSE)
 
-
 if(ENABLE_GNOME_NETWORKMANAGER)
     if(ENABLE_GNOME_GDBUS)
         message("networkmanager building with gdbus")
@@ -142,6 +141,7 @@ if(ENABLE_GNOME_NETWORKMANAGER)
     endif()
 else()
     message("networkmanager building with netsrvmgr")
+    add_definitions(-DENABLE_GET_WIFI_CREDENTIALS)
     target_sources(${MODULE_NAME} PRIVATE NetworkManagerRDKProxy.cpp)
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${IARMBUS_LIBRARIES})
@@ -161,7 +161,6 @@ add_library(${PLUGIN_LEGACY_DEPRECATED_NETWORK} SHARED
         NetworkManagerLogger.cpp
         Module.cpp
 )
-
 target_link_libraries(${PLUGIN_LEGACY_DEPRECATED_NETWORK}  PRIVATE
                                         ${NAMESPACE}Core::${NAMESPACE}Core
                                         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
@@ -183,9 +182,12 @@ add_library(${PLUGIN_LEGACY_DEPRECATED_WIFI} SHARED
         Module.cpp
 )
 
+target_include_directories(${PLUGIN_LEGACY_DEPRECATED_WIFI} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+
 target_link_libraries(${PLUGIN_LEGACY_DEPRECATED_WIFI}  PRIVATE
                                         ${NAMESPACE}Core::${NAMESPACE}Core
                                         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+                                        ${IARMBUS_LIBRARIES}
                                     )
 
 if (USE_RDK_LOGGER)

--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -20,6 +20,10 @@
 #include "NetworkManagerLogger.h"
 #include "NetworkManagerJsonEnum.h"
 
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+#include "libIBus.h"
+#endif
+
 using namespace std;
 using namespace WPEFramework::Plugin;
 #define API_VERSION_NUMBER_MAJOR 2
@@ -27,6 +31,10 @@ using namespace WPEFramework::Plugin;
 #define API_VERSION_NUMBER_PATCH 0
 #define NETWORK_MANAGER_CALLSIGN    "org.rdk.NetworkManager.1"
 #define SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS 500
+
+#define IARM_BUS_MFRLIB_NAME                                "MFRLib"
+#define IARM_BUS_MFRLIB_API_WIFI_Credentials                "mfrWifiCredentials"
+
 
 #define LOG_INPARAM() { string json; parameters.ToString(json); NMLOG_INFO("params=%s", json.c_str() ); }
 #define LOG_OUTPARAM() { string json; response.ToString(json); NMLOG_INFO("response=%s", json.c_str() ); }
@@ -209,6 +217,9 @@ namespace WPEFramework
             Register("saveSSID",                          &WiFiManager::saveSSID, this);
             Register("startScan",                         &WiFiManager::startScan, this);
             Register("stopScan",                          &WiFiManager::stopScan, this);
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+            Register("retrieveSSID",                      &WiFiManager::retrieveSSID, this);
+#endif
         }
 
         /**
@@ -230,6 +241,9 @@ namespace WPEFramework
             Unregister("saveSSID");
             Unregister("startScan");
             Unregister("stopScan");
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+            Unregister("retrieveSSID");
+#endif
         }
 
         uint32_t WiFiManager::cancelWPSPairing (const JsonObject& parameters, JsonObject& response)
@@ -304,6 +318,51 @@ namespace WPEFramework
 
             returnJson(rc);
         }
+
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+        uint32_t WiFiManager::retrieveSSID (const JsonObject& parameters, JsonObject& response)
+        {
+            LOG_INPARAM();
+            uint32_t rc = Core::ERROR_GENERAL;
+
+            auto _nwmgr = m_service->QueryInterfaceByCallsign<Exchange::INetworkManager>(NETWORK_MANAGER_CALLSIGN);
+            if (!_nwmgr)
+                return Core::ERROR_UNAVAILABLE;
+
+            Exchange::INetworkManager::WiFiConnectTo credInfo{};
+
+            IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t param{0};
+            param.requestType = WIFI_GET_CREDENTIALS;
+
+            if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_WIFI_Credentials, (void *) &param, sizeof(param)))
+            {
+                credInfo.ssid            = param.wifiCredentials.cSSID;
+                credInfo.passphrase      = param.wifiCredentials.cPassword;
+                credInfo.security        = static_cast<WPEFramework::Exchange::INetworkManager::WIFISecurityMode>(param.wifiCredentials.iSecurityMode);
+
+                response["ssid"]         = credInfo.ssid;
+                response["passphrase"]   = "[HIDDEN]";  // passphrase hidden for logging
+                response["securityMode"] = JsonValue(credInfo.security);
+                response["success"]      = true;
+
+                string json;
+                response.ToString(json);
+                NMLOG_INFO("response=%s", json.c_str());
+
+                response["passphrase"]   =  credInfo.passphrase; // overwrite with correct passphrase after logging
+
+                NMLOG_INFO ("retrieveSSID Success");
+                NMLOG_INFO ("SSID: %s, passphrase: %s, security mode: %d", param.wifiCredentials.cSSID,
+                        param.wifiCredentials.cPassword, param.wifiCredentials.iSecurityMode);
+
+                rc = Core::ERROR_NONE;
+            }
+            else
+                NMLOG_ERROR ("retrieveSSID Failed");
+
+            return rc;
+        }
+#endif
 
         uint32_t WiFiManager::getConnectedSSID (const JsonObject& parameters, JsonObject& response)
         {

--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -35,6 +35,44 @@ typedef enum _WiFiErrorCode_t {
     WIFI_AUTH_FAILED                /**< The connection failed due to auth failure */
 } WiFiErrorCode_t;
 
+#define SSID_SIZE                   32
+#define WIFI_MAX_PASSWORD_LEN       64
+
+/**
+ * @brief WIFI API return status
+ *
+ */
+typedef enum _WIFI_API_RESULT {
+    WIFI_API_RESULT_SUCCESS = 0,                  ///< operation is successful
+    WIFI_API_RESULT_FAILED,                       ///< Operation general error. This enum is deprecated
+    WIFI_API_RESULT_NULL_PARAM,                   ///< NULL argument is passed to the module
+    WIFI_API_RESULT_INVALID_PARAM,                ///< Invalid argument is passed to the module
+    WIFI_API_RESULT_NOT_INITIALIZED,              ///< module not initialized
+    WIFI_API_RESULT_OPERATION_NOT_SUPPORTED,      ///< operation not supported in the specific platform
+    WIFI_API_RESULT_READ_WRITE_FAILED,            ///< flash read/write failed or crc check failed
+    WIFI_API_RESULT_MAX                           ///< Out of range - required to be the last item of the enum
+} WIFI_API_RESULT;
+/**
+ * @brief WIFI credentials data struct
+ *
+ */
+typedef struct {
+    char cSSID[SSID_SIZE+1];                      ///< SSID field.
+    char cPassword[WIFI_MAX_PASSWORD_LEN+1];      ///< password field
+    int  iSecurityMode;                           ///< security mode. Platform dependent and caller is responsible to validate it
+} WIFI_DATA;
+
+typedef enum _WifiRequestType {
+    WIFI_GET_CREDENTIALS = 0,
+    WIFI_SET_CREDENTIALS = 1
+} WifiRequestType_t;
+
+typedef struct _IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t {
+    WIFI_DATA wifiCredentials;
+    WifiRequestType_t requestType;
+    WIFI_API_RESULT returnVal;
+} IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t;
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -73,6 +111,9 @@ namespace WPEFramework {
             uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response);
             uint32_t isPaired(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+            uint32_t retrieveSSID(const JsonObject& parameters, JsonObject& response);
+#endif
             //End methods
 
             //Begin events


### PR DESCRIPTION
Reason for change: Implemented new API org.rdk.Wifi.retrieveSSID 
Test Procedure: Call org.rdk.Wifi.retrieveSSID and verify that the retrieved credentials are the same as those stored on the device.