### PR TITLE
RDK-55421 : Implementation of new API - org.rdk.Wifi.retrieveSSID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ set_target_properties(${MODULE_NAME} PROPERTIES
                                      CXX_STANDARD_REQUIRED YES
                                      FRAMEWORK FALSE)
 
-
 if(ENABLE_GNOME_NETWORKMANAGER)
     if(ENABLE_GNOME_GDBUS)
         message("networkmanager building with gdbus")
@@ -142,6 +141,7 @@ if(ENABLE_GNOME_NETWORKMANAGER)
     endif()
 else()
     message("networkmanager building with netsrvmgr")
+    add_definitions(-DENABLE_GET_WIFI_CREDENTIALS)
     target_sources(${MODULE_NAME} PRIVATE NetworkManagerRDKProxy.cpp)
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${IARMBUS_LIBRARIES})
@@ -161,7 +161,6 @@ add_library(${PLUGIN_LEGACY_DEPRECATED_NETWORK} SHARED
         NetworkManagerLogger.cpp
         Module.cpp
 )
-
 target_link_libraries(${PLUGIN_LEGACY_DEPRECATED_NETWORK}  PRIVATE
                                         ${NAMESPACE}Core::${NAMESPACE}Core
                                         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
@@ -183,9 +182,12 @@ add_library(${PLUGIN_LEGACY_DEPRECATED_WIFI} SHARED
         Module.cpp
 )
 
+target_include_directories(${PLUGIN_LEGACY_DEPRECATED_WIFI} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+
 target_link_libraries(${PLUGIN_LEGACY_DEPRECATED_WIFI}  PRIVATE
                                         ${NAMESPACE}Core::${NAMESPACE}Core
                                         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+                                        ${IARMBUS_LIBRARIES}
                                     )
 
 if (USE_RDK_LOGGER)

--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -35,6 +35,44 @@ typedef enum _WiFiErrorCode_t {
     WIFI_AUTH_FAILED                /**< The connection failed due to auth failure */
 } WiFiErrorCode_t;
 
+#define SSID_SIZE                   32
+#define WIFI_MAX_PASSWORD_LEN       64
+
+/**
+ * @brief WIFI API return status
+ *
+ */
+typedef enum _WIFI_API_RESULT {
+    WIFI_API_RESULT_SUCCESS = 0,                  ///< operation is successful
+    WIFI_API_RESULT_FAILED,                       ///< Operation general error. This enum is deprecated
+    WIFI_API_RESULT_NULL_PARAM,                   ///< NULL argument is passed to the module
+    WIFI_API_RESULT_INVALID_PARAM,                ///< Invalid argument is passed to the module
+    WIFI_API_RESULT_NOT_INITIALIZED,              ///< module not initialized
+    WIFI_API_RESULT_OPERATION_NOT_SUPPORTED,      ///< operation not supported in the specific platform
+    WIFI_API_RESULT_READ_WRITE_FAILED,            ///< flash read/write failed or crc check failed
+    WIFI_API_RESULT_MAX                           ///< Out of range - required to be the last item of the enum
+} WIFI_API_RESULT;
+/**
+ * @brief WIFI credentials data struct
+ *
+ */
+typedef struct {
+    char cSSID[SSID_SIZE+1];                      ///< SSID field.
+    char cPassword[WIFI_MAX_PASSWORD_LEN+1];      ///< password field
+    int  iSecurityMode;                           ///< security mode. Platform dependent and caller is responsible to validate it
+} WIFI_DATA;
+
+typedef enum _WifiRequestType {
+    WIFI_GET_CREDENTIALS = 0,
+    WIFI_SET_CREDENTIALS = 1
+} WifiRequestType_t;
+
+typedef struct _IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t {
+    WIFI_DATA wifiCredentials;
+    WifiRequestType_t requestType;
+    WIFI_API_RESULT returnVal;
+} IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t;
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -73,6 +111,9 @@ namespace WPEFramework {
             uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response);
             uint32_t isPaired(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
+#ifdef ENABLE_GET_WIFI_CREDENTIALS
+            uint32_t retrieveSSID(const JsonObject& parameters, JsonObject& response);
+#endif
             //End methods
 
             //Begin events


### PR DESCRIPTION
Reason for change: Implemented new API org.rdk.Wifi.retrieveSSID 
Test Procedure: Call org.rdk.Wifi.retrieveSSID and verify that the retrieved credentials are the same as those stored on the device.