### PR TITLE
RDK-55421 : Implementation of new API - org.rdk.Wifi.retrieveSSID

### DIFF
--- a/.github/workflows/gnome_unit_test.yml
+++ b/.github/workflows/gnome_unit_test.yml
@@ -73,6 +73,16 @@ jobs:
         with:
           path: networkmanager
           
+      - name: Generate IARM headers
+        run: |
+            touch install/usr/lib/libIARMBus.so 
+            mkdir -p install/usr/include/rdk/iarmbus
+            touch install/usr/include/rdk/iarmbus/libIARM.h
+            cd "${{github.workspace}}/networkmanager/Tests/"
+            mkdir -p headers/rdk/iarmbus
+            cd headers
+            touch rdk/iarmbus/libIARM.h rdk/iarmbus/libIBus.h
+
       - name: Build networkmanager with Gnome Proxy
         run: >
           cmake
@@ -81,7 +91,9 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
           -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install/usr"
           -DCMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
-          -DCMAKE_CXX_FLAGS=" -fprofile-arcs -ftest-coverage "
+          -DCMAKE_CXX_FLAGS=" -fprofile-arcs -ftest-coverage 
+          -I ${{github.workspace}}/networkmanager/Tests/headers/rdk/iarmbus
+          --include ${{github.workspace}}/networkmanager/Tests/mocks/Iarm.h"
           -DENABLE_GNOME_NETWORKMANAGER=ON
           -DENABLE_UNIT_TESTING=ON
           &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,12 @@ add_library(${PLUGIN_LEGACY_DEPRECATED_WIFI} SHARED
         Module.cpp
 )
 
+target_include_directories(${PLUGIN_LEGACY_DEPRECATED_WIFI} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+
 target_link_libraries(${PLUGIN_LEGACY_DEPRECATED_WIFI}  PRIVATE
                                         ${NAMESPACE}Core::${NAMESPACE}Core
                                         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+                                        ${IARMBUS_LIBRARIES}
                                     )
 
 if (USE_RDK_LOGGER)

--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -19,6 +19,8 @@
 #include "LegacyPlugin_WiFiManagerAPIs.h"
 #include "NetworkManagerLogger.h"
 #include "NetworkManagerJsonEnum.h"
+#include "libIBus.h"
+
 
 using namespace std;
 using namespace WPEFramework::Plugin;
@@ -27,6 +29,10 @@ using namespace WPEFramework::Plugin;
 #define API_VERSION_NUMBER_PATCH 0
 #define NETWORK_MANAGER_CALLSIGN    "org.rdk.NetworkManager.1"
 #define SUBSCRIPTION_TIMEOUT_IN_MILLISECONDS 500
+
+#define IARM_BUS_MFRLIB_NAME                                "MFRLib"
+#define IARM_BUS_MFRLIB_API_WIFI_Credentials                "mfrWifiCredentials"
+
 
 #define LOG_INPARAM() { string json; parameters.ToString(json); NMLOG_INFO("params=%s", json.c_str() ); }
 #define LOG_OUTPARAM() { string json; response.ToString(json); NMLOG_INFO("response=%s", json.c_str() ); }
@@ -209,6 +215,7 @@ namespace WPEFramework
             Register("saveSSID",                          &WiFiManager::saveSSID, this);
             Register("startScan",                         &WiFiManager::startScan, this);
             Register("stopScan",                          &WiFiManager::stopScan, this);
+            Register("retrieveSSID",                      &WiFiManager::retrieveSSID, this);
         }
 
         /**
@@ -230,6 +237,7 @@ namespace WPEFramework
             Unregister("saveSSID");
             Unregister("startScan");
             Unregister("stopScan");
+            Unregister("retrieveSSID");
         }
 
         uint32_t WiFiManager::cancelWPSPairing (const JsonObject& parameters, JsonObject& response)
@@ -303,6 +311,49 @@ namespace WPEFramework
                 rc = Core::ERROR_UNAVAILABLE;
 
             returnJson(rc);
+        }
+
+        uint32_t WiFiManager::retrieveSSID (const JsonObject& parameters, JsonObject& response)
+        {
+            LOG_INPARAM();
+            uint32_t rc = Core::ERROR_GENERAL;
+
+            auto _nwmgr = m_service->QueryInterfaceByCallsign<Exchange::INetworkManager>(NETWORK_MANAGER_CALLSIGN);
+            if (!_nwmgr)
+                return Core::ERROR_UNAVAILABLE;
+
+            Exchange::INetworkManager::WiFiConnectTo credInfo{};
+
+            IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t param{0};
+            param.requestType = WIFI_GET_CREDENTIALS;
+
+            if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_WIFI_Credentials, (void *) &param, sizeof(param)))
+            {
+                credInfo.ssid            = param.wifiCredentials.cSSID;
+                credInfo.passphrase      = param.wifiCredentials.cPassword;
+                credInfo.security        = static_cast<WPEFramework::Exchange::INetworkManager::WIFISecurityMode>(param.wifiCredentials.iSecurityMode);
+
+                response["ssid"]         = credInfo.ssid;
+                response["passphrase"]   = "[HIDDEN]";  // passphrase hidden for logging
+                response["securityMode"] = JsonValue(credInfo.security);
+                response["success"]      = true;
+
+                string json;
+                response.ToString(json);
+                NMLOG_INFO("response=%s", json.c_str());
+
+                response["passphrase"]   =  credInfo.passphrase; // overwrite with correct passphrase after logging
+
+                NMLOG_INFO ("retrieveSSID Success");
+                NMLOG_DEBUG ("SSID: %s, passphrase: %s, security mode: %d", param.wifiCredentials.cSSID,
+                        param.wifiCredentials.cPassword, param.wifiCredentials.iSecurityMode);
+
+                rc = Core::ERROR_NONE;
+            }
+            else
+                NMLOG_ERROR ("retrieveSSID Failed");
+
+            return rc;
         }
 
         uint32_t WiFiManager::getConnectedSSID (const JsonObject& parameters, JsonObject& response)

--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -35,6 +35,44 @@ typedef enum _WiFiErrorCode_t {
     WIFI_AUTH_FAILED                /**< The connection failed due to auth failure */
 } WiFiErrorCode_t;
 
+#define SSID_SIZE                   32
+#define WIFI_MAX_PASSWORD_LEN       64
+
+/**
+ * @brief WIFI API return status
+ *
+ */
+typedef enum _WIFI_API_RESULT {
+    WIFI_API_RESULT_SUCCESS = 0,                  ///< operation is successful
+    WIFI_API_RESULT_FAILED,                       ///< Operation general error. This enum is deprecated
+    WIFI_API_RESULT_NULL_PARAM,                   ///< NULL argument is passed to the module
+    WIFI_API_RESULT_INVALID_PARAM,                ///< Invalid argument is passed to the module
+    WIFI_API_RESULT_NOT_INITIALIZED,              ///< module not initialized
+    WIFI_API_RESULT_OPERATION_NOT_SUPPORTED,      ///< operation not supported in the specific platform
+    WIFI_API_RESULT_READ_WRITE_FAILED,            ///< flash read/write failed or crc check failed
+    WIFI_API_RESULT_MAX                           ///< Out of range - required to be the last item of the enum
+} WIFI_API_RESULT;
+/**
+ * @brief WIFI credentials data struct
+ *
+ */
+typedef struct {
+    char cSSID[SSID_SIZE+1];                      ///< SSID field.
+    char cPassword[WIFI_MAX_PASSWORD_LEN+1];      ///< password field
+    int  iSecurityMode;                           ///< security mode. Platform dependent and caller is responsible to validate it
+} WIFI_DATA;
+
+typedef enum _WifiRequestType {
+    WIFI_GET_CREDENTIALS = 0,
+    WIFI_SET_CREDENTIALS = 1
+} WifiRequestType_t;
+
+typedef struct _IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t {
+    WIFI_DATA wifiCredentials;
+    WifiRequestType_t requestType;
+    WIFI_API_RESULT returnVal;
+} IARM_BUS_MFRLIB_API_WIFI_Credentials_Param_t;
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -73,6 +111,7 @@ namespace WPEFramework {
             uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response);
             uint32_t isPaired(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
+            uint32_t retrieveSSID(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             //Begin events


### PR DESCRIPTION
Reason for change: Implemented new API org.rdk.Wifi.retrieveSSID 
Test Procedure: Call org.rdk.Wifi.retrieveSSID and verify that the retrieved credentials are the same as those stored on the device.