### PR TITLE
RDK-55421 : Implement org.rdk.Wifi.retrieveSSID API

### DIFF
--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -635,18 +635,20 @@ namespace WPEFramework
                 size_t pos;
 
                 // Fetch ssid value
-                pos = line.find(ssidPattern);
-                if (pos != std::string::npos)
-                {
-                    pos += ssidPattern.length();
-                    size_t end = line.find('"', pos + 1);
-                    if (end == std::string::npos)
+                if (ssid.empty()) {
+                    pos = line.find(ssidPattern);
+                    if (pos != std::string::npos)
                     {
-                        end = line.length();
+                        pos += ssidPattern.length();
+                        size_t end = line.find('"', pos + 1);
+                        if (end == std::string::npos)
+                        {
+                            end = line.length();
+                        }
+                        ssid = line.substr(pos + 1, end - pos - 1);
+                        NMLOG_DEBUG("SSID found");
+                        continue;
                     }
-                    ssid = line.substr(pos + 1, end - pos - 1);
-                    NMLOG_DEBUG("SSID found");
-                    continue;
                 }
 
                 if (!ssid.empty()) {


### PR DESCRIPTION
Reason for change: Check if the ssid string is empty
Test Procedure: Build and verified
Risks: Low
Priority: P1