### PR TITLE
RDKEMW-1618 - GetConnectedSSID is returning empty string for noise

### DIFF
--- a/NetworkManagerGnomeWIFI.cpp
+++ b/NetworkManagerGnomeWIFI.cpp
@@ -188,6 +188,7 @@ namespace WPEFramework
         {
             guint32     flags, wpaFlags, rsnFlags, freq, bitrate;
             guint8      strength;
+            gint16      noise;
             GBytes     *ssid;
             const char *hwaddr;
             NM80211Mode mode;
@@ -201,6 +202,7 @@ namespace WPEFramework
             mode      = nm_access_point_get_mode(AccessPoint);
             bitrate   = nm_access_point_get_max_bitrate(AccessPoint);
             strength  = nm_access_point_get_strength(AccessPoint);
+            noise     = 0; /* ToDo: Returning as 0 as of now. Need to fetch actual noise value */
 
             /* Convert to strings */
             if (ssid) {
@@ -229,6 +231,7 @@ namespace WPEFramework
             NMLOG_DEBUG("bssid: %s", wifiInfo.bssid.c_str());
             wifiInfo.frequency = std::to_string((double)freq/1000);
             wifiInfo.rate = std::to_string(bitrate);
+            wifiInfo.noise = std::to_string(noise);
             NMLOG_DEBUG("bitrate : %s kbit/s", wifiInfo.rate.c_str());
             //TODO signal strenght to dBm
             wifiInfo.strength = std::string(nmUtils::convertPercentageToSignalStrengtStr(strength));

--- a/gdbus/NetworkManagerGdbusUtils.cpp
+++ b/gdbus/NetworkManagerGdbusUtils.cpp
@@ -369,6 +369,7 @@ namespace WPEFramework
         {
             guint32 flags= 0, wpaFlags= 0, rsnFlags= 0, freq= 0, bitrate= 0;
             uint8_t strength = 0;
+            gint16  noise = 0;
             NM80211Mode mode = NM_802_11_MODE_UNKNOWN;
             bool ret = false;
             GVariant* ssidVariant = NULL;
@@ -425,6 +426,7 @@ namespace WPEFramework
                 wifiInfo.frequency = std::to_string((double)freq/1000);
                 wifiInfo.rate = std::to_string(bitrate);
                 wifiInfo.security = static_cast<Exchange::INetworkManager::WIFISecurityMode>(wifiSecurityModeFromApFlags(flags, wpaFlags, rsnFlags));
+                wifiInfo.noise = std::to_string(noise); /* ToDo: Returning 0 as of now. Need to change to return actual noise value */
 
                 // NMLOG_DEBUG("SSID: %s", wifiInfo.m_ssid.c_str());
                 // NMLOG_DEBUG("bssid %s", wifiInfo.m_bssid.c_str());


### PR DESCRIPTION
Reason for change: Changed GetConnectedSSID to return noise value as 0 instead of empty string
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>
