### PR TITLE
RDK-56182 : Updated `GetWiFiSignalQuality` to include SNR

### DIFF
--- a/INetworkManager.h
+++ b/INetworkManager.h
@@ -252,7 +252,7 @@ namespace WPEFramework
             virtual uint32_t StartWPS(const WiFiWPS& method /* @in */, const string& pin /* @in */) = 0;
             virtual uint32_t StopWPS(void) = 0;
             virtual uint32_t GetWifiState(WiFiState &state /* @out */) = 0;
-            virtual uint32_t GetWiFiSignalStrength(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */) = 0;
+            virtual uint32_t GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */) = 0;
             virtual uint32_t GetSupportedSecurityModes(ISecurityModeIterator*& modes/* @out */) const = 0;
 
             /* @brief Set the network manager plugin log level */
@@ -276,7 +276,7 @@ namespace WPEFramework
                 // WiFi Notifications that other processes can subscribe to
                 virtual void onAvailableSSIDs(const string jsonOfScanResults /* @in */) = 0;
                 virtual void onWiFiStateChange(const WiFiState state /* @in */) = 0;
-                virtual void onWiFiSignalStrengthChange(const string ssid /* @in */, const string strength /* @in */, const WiFiSignalQuality quality /* @in */) = 0;
+                virtual void onWiFiSignalQualityChange(const string ssid /* @in */, const string strength /* @in */, const string noise /* @in */, const string snr /* @in */, const WiFiSignalQuality quality /* @in */) = 0;
             };
 
             // Allow other processes to register/unregister from our notifications

--- a/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -804,11 +804,11 @@ namespace WPEFramework
 
                 if (!m_subsWiFiStrengthChange)
                 {
-                    errCode = m_networkmanager->Subscribe<JsonObject>(5000, _T("onWiFiSignalStrengthChange"), &WiFiManager::onWiFiSignalStrengthChange);
+                    errCode = m_networkmanager->Subscribe<JsonObject>(5000, _T("onWiFiSignalQualityChange"), &WiFiManager::onWiFiSignalQualityChange);
                     if (Core::ERROR_NONE == errCode)
                         m_subsWiFiStrengthChange = true;
                     else
-                        NMLOG_ERROR("Subscribe to onWiFiSignalStrengthChange failed, errCode: %u", errCode);
+                        NMLOG_ERROR("Subscribe to onWiFiSignalQualityChange failed, errCode: %u", errCode);
                 }
             }
             else
@@ -926,7 +926,7 @@ namespace WPEFramework
             return;
         }
 
-        void WiFiManager::onWiFiSignalStrengthChange(const JsonObject& parameters)
+        void WiFiManager::onWiFiSignalQualityChange(const JsonObject& parameters)
         {
             JsonObject legacyParams;
             legacyParams["signalStrength"] = parameters["strength"];

--- a/LegacyPlugin_WiFiManagerAPIs.h
+++ b/LegacyPlugin_WiFiManagerAPIs.h
@@ -66,7 +66,7 @@ namespace WPEFramework {
             //Begin events
             static void onWiFiStateChange(const JsonObject& parameters);
             static void onAvailableSSIDs(const JsonObject& parameters);
-            static void onWiFiSignalStrengthChange(const JsonObject& parameters);
+            static void onWiFiSignalQualityChange(const JsonObject& parameters);
 
             //End events
 

--- a/NetworkManager.h
+++ b/NetworkManager.h
@@ -94,9 +94,9 @@ namespace WPEFramework
                     _parent.onWiFiStateChange(state);
                 }
 
-                void onWiFiSignalStrengthChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality) override
+                void onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality) override
                 {
-                    _parent.onWiFiSignalStrengthChange(ssid, strength, quality);
+                    _parent.onWiFiSignalQualityChange(ssid, strength, noise, snr, quality);
                 }
 
                 // The activated/deactived methods are part of the RPC::IRemoteConnection::INotification
@@ -261,7 +261,7 @@ namespace WPEFramework
             uint32_t StartWPS(const JsonObject& parameters, JsonObject& response);
             uint32_t StopWPS(const JsonObject& parameters, JsonObject& response);
             uint32_t GetWifiState(const JsonObject& parameters, JsonObject& response);
-            uint32_t GetWiFiSignalStrength(const JsonObject& parameters, JsonObject& response);
+            uint32_t GetWiFiSignalQuality(const JsonObject& parameters, JsonObject& response);
             uint32_t GetSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
 
             void onInterfaceStateChange(const Exchange::INetworkManager::InterfaceState state, const string interface);
@@ -270,7 +270,7 @@ namespace WPEFramework
             void onInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState);
             void onAvailableSSIDs(const string jsonOfScanResults);
             void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state);
-            void onWiFiSignalStrengthChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality);
+            void onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
 
         private:
             uint32_t _connectionId;

--- a/NetworkManager.json
+++ b/NetworkManager.json
@@ -123,24 +123,34 @@
             "example": "password"
         },
         "security":{
-            "summary": "The security mode. See `getSupportedsecurityModes`.",
+            "summary": "The security mode. See `GetSupportedSecurityModes`.",
             "type": "integer",
-            "example": 6
+            "example": 2
         },
         "strength":{
+            "summary": "The WiFi Signal RSSI value in dBm",
+            "type": "string",
+            "example": "-32"
+        },
+        "noise":{
+            "summary": "The WiFi Signal Noise detected in dBm",
+            "type": "string",
+            "example": "-106"
+        },
+        "snr":{
             "summary": "Signal to Noise Ratio(SNR) in dBm",
             "type": "string",
-            "example": "-27.000000"
+            "example": "74"
         },
         "quality":{
-            "summary": "Signal strength Quality",
+            "summary": "WiFi Quality based on Signal to Noise Ratio (SNR)",
             "type": "string",
             "example": "Excellent"
         },
         "frequency":{
             "summary": "The supported frequency for this SSID in GHz",
             "type": "string",
-            "example": "2.442000"
+            "example": "2.4420"
         },
         "errors": {
             "summary": "Error string of scan failure",
@@ -1000,7 +1010,7 @@
             }
         },
         "WiFiConnect":{
-            "summary": "Initiates request to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `AddToKnownSSIDs`.",
+            "summary": "Initiates request to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. The security mode is decided based on the highest security mode provided by the SSID. Also when called with no arguments, this method attempts to connect to the saved SSID and password. See `AddToKnownSSIDs`.",
             "events":{
                 "onWiFiStateChange" : "Triggered when Wifi state changes to CONNECTING, CONNECTED ."
             },
@@ -1012,11 +1022,6 @@
                     },
                     "passphrase": {
                         "$ref": "#/definitions/passphrase"
-                    },
-                    "security": {
-                        "summary": "The security mode is decided based on the highest security mode provided by the SSID",
-                        "type": "integer",
-                        "example": 2
                     },
                     "ca_cert": {
                         "summary": "The ca_cert to be used for EAP",
@@ -1119,12 +1124,10 @@
                     "security":{
                         "summary": "The security mode. See the `connect` method",
                         "type": "string",
-                        "example": "5"
+                        "example": "2"
                     },
                     "strength": {
-                        "summary": "The Signal RSSI value in dBm",
-                        "type": "string",
-                        "example": "-27.000000"
+                        "$ref": "#/definitions/strength"
                     },
                     "frequency": {
                         "$ref": "#/definitions/frequency"
@@ -1132,12 +1135,10 @@
                     "rate":{
                         "summary": "The physical data rate in Mbps",
                         "type": "string",
-                        "example": "144.000000"
+                        "example": "144"
                     },
                     "noise":{
-                        "summary": "The average noise strength in dBm",
-                        "type": "string",
-                        "example": "-121.000000"
+                        "$ref": "#/definitions/noise"
                     },
                     "success":{
                         "$ref": "#/definitions/success"
@@ -1215,10 +1216,10 @@
                 ]
             }
         },
-        "GetWiFiSignalStrength":{
-            "summary": "Get WiFiSignalStrength of connected SSID. The signal quality is identifed based on the Signal to Noise ratio which is calculated as SNR = rssi - noise. The possible states are\n* 'Excellent' : More than 40 dBm\n* 'Good' : 40 dBm to 25 dBm\n* 'Fair' : 25 dBm to 18 dBm\n* 'Weak' : 18 dBm to 0 dBm\n* 'Disconnected' : 0 dBm\n",
+        "GetWiFiSignalQuality":{
+            "summary": "Get WiFi signal quality of currently connected SSID. The signal quality is identifed based on the Signal to Noise ratio which is calculated as SNR = rssi - noise. The possible states are\n* 'Excellent'    : More than 40 dBm\n* 'Good'         : 40 dBm to 25 dBm\n* 'Fair'         : 25 dBm to 18 dBm\n* 'Weak'         : 18 dBm to 0 dBm\n* 'Disconnected' : 0 dBm\n",
             "events":{
-                "onWiFiSignalStrengthChange" : "Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak."
+                "onWiFiSignalQualityChange" : "Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak."
             },
             "result": {
                 "type": "object",
@@ -1226,11 +1227,17 @@
                     "ssid": {
                         "$ref": "#/definitions/ssid"
                     },
+                    "quality":{
+                        "$ref": "#/definitions/quality"
+                    },
+                    "snr": {
+                        "$ref": "#/definitions/snr"
+                    },
                     "strength": {
                         "$ref": "#/definitions/strength"
                     },
-                    "quality":{
-                        "$ref": "#/definitions/quality"
+                    "noise": {
+                        "$ref": "#/definitions/noise"
                     },
                     "success":{
                         "$ref": "#/definitions/success"
@@ -1238,13 +1245,15 @@
                 },
                 "required": [
                     "ssid",
-                    "strength",
                     "quality",
+                    "snr",
+                    "strength",
+                    "noise",
                     "success"
                 ]
             }
         },
-        "GetSupportedsecurityModes":{
+        "GetSupportedSecurityModes":{
             "summary": "Returns the Wifi security modes that the device supports.",
             "result": {
                 "type": "object",
@@ -1491,25 +1500,33 @@
                 ]
             }
         },
-        "onWiFiSignalStrengthChange":{
-            "summary": "Triggered when WIFI connection Signal Strength get changed.",
+        "onWiFiSignalQualityChange":{
+            "summary": "Triggered when WIFI Signal quality changed which is decided based on SNR value which is defined in `GetWiFiSignalQuality`",
             "params": {
                 "type": "object",
                 "properties": {
                     "ssid":{
                         "$ref": "#/definitions/ssid"
                     },
+                    "quality":{
+                        "$ref": "#/definitions/quality"
+                    },
+                    "snr":{
+                        "$ref": "#/definitions/snr"
+                    },
                     "strength":{
                         "$ref": "#/definitions/strength"
                     },
-                    "quality":{
-                        "$ref": "#/definitions/quality"
+                    "noise":{
+                        "$ref": "#/definitions/noise"
                     }
                 },
                 "required": [
                     "ssid",
+                    "quality",
+                    "snr",
                     "strength",
-                    "quality"
+                    "noise"
                 ]
             }
         }

--- a/NetworkManagerGnomeProxy.cpp
+++ b/NetworkManagerGnomeProxy.cpp
@@ -681,7 +681,7 @@ namespace WPEFramework
         }
 
 #if 0
-        uint32_t NetworkManagerImplementation::GetWiFiSignalStrength(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
+        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
         {
             float rssi = 0.0f;
             float noise = 0.0f;
@@ -699,7 +699,7 @@ namespace WPEFramework
                     floatSignalStrength = 0.0;
 
                 strengthOut = static_cast<unsigned int>(floatSignalStrength);
-                NMLOG_INFO ("WiFiSignalStrength in dB = %u",strengthOut);
+                NMLOG_INFO ("WiFiSignalQuality in dB = %u",strengthOut);
 
                 if (strengthOut == 0)
                 {
@@ -725,7 +725,7 @@ namespace WPEFramework
 
                 signalStrength = std::to_string(strengthOut);
 
-                NMLOG_INFO ("GetWiFiSignalStrength success");
+                NMLOG_INFO ("GetWiFiSignalQuality success");
             
                 rc = Core::ERROR_NONE;
             }

--- a/NetworkManagerGnomeWIFI.cpp
+++ b/NetworkManagerGnomeWIFI.cpp
@@ -217,7 +217,9 @@ namespace WPEFramework
             }
 
             wifiInfo.bssid = (hwaddr != nullptr) ? hwaddr : "-----";
-            wifiInfo.frequency = std::to_string((double)freq/1000);
+            std::string freqStr = std::to_string((double)freq/1000);
+            wifiInfo.frequency = freqStr.substr(0, 5);
+
             wifiInfo.rate = std::to_string(bitrate);
             if(noise <= 0 || noise >= DEFAULT_NOISE)
                 wifiInfo.noise = std::to_string(noise);

--- a/NetworkManagerImplementation.h
+++ b/NetworkManagerImplementation.h
@@ -215,7 +215,7 @@ namespace WPEFramework
                 uint32_t StartWPS(const WiFiWPS& method /* @in */, const string& wps_pin /* @in */) override;
                 uint32_t StopWPS(void) override;
                 uint32_t GetWifiState(WiFiState &state) override;
-                uint32_t GetWiFiSignalStrength(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */) override;
+                uint32_t GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */) override;
 
                 uint32_t SetStunEndpoint (string const endpoint /* @in */, const uint32_t port /* @in */, const uint32_t bindTimeout /* @in */, const uint32_t cacheTimeout /* @in */) override;
                 uint32_t GetStunEndpoint (string &endpoint /* @out */, uint32_t& port /* @out */, uint32_t& bindTimeout /* @out */, uint32_t& cacheTimeout /* @out */) const override;
@@ -255,7 +255,7 @@ namespace WPEFramework
                 void ReportInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState);
                 void ReportAvailableSSIDs(const JsonArray &arrayofWiFiScanResults);
                 void ReportWiFiStateChange(const Exchange::INetworkManager::WiFiState state);
-                void ReportWiFiSignalStrengthChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality);
+                void ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
 
             private:
                 void platform_init(void);
@@ -263,8 +263,8 @@ namespace WPEFramework
                 void executeExternally(NetworkEvents event, const string commandToExecute, string& response);
                 void threadEventRegistration(void);
                 void filterScanResults(JsonArray &ssids);
-                void startWiFiSignalStrengthMonitor(int interval);
-                void stopWiFiSignalStrengthMonitor();
+                void startWiFiSignalQualityMonitor(int interval);
+                void stopWiFiSignalQualityMonitor();
                 void monitorThreadFunction(int interval);
 
             private:

--- a/NetworkManagerJsonRpc.cpp
+++ b/NetworkManagerJsonRpc.cpp
@@ -81,7 +81,7 @@ namespace WPEFramework
             Register("StartWPS",                          &NetworkManager::StartWPS, this);
             Register("StopWPS",                           &NetworkManager::StopWPS, this);
             Register("GetWifiState",                      &NetworkManager::GetWifiState, this);
-            Register("GetWiFiSignalStrength",             &NetworkManager::GetWiFiSignalStrength, this);
+            Register("GetWiFiSignalQuality",              &NetworkManager::GetWiFiSignalQuality, this);
             Register("GetSupportedSecurityModes",         &NetworkManager::GetSupportedSecurityModes, this);
         }
 
@@ -118,7 +118,7 @@ namespace WPEFramework
             Unregister("StartWPS");
             Unregister("StopWPS");
             Unregister("GetWifiState");
-            Unregister("GetWiFiSignalStrength");
+            Unregister("GetWiFiSignalQuality");
             Unregister("GetSupportedSecurityModes");
         }
 
@@ -885,25 +885,29 @@ namespace WPEFramework
             returnJson(rc);
         }
 
-        uint32_t NetworkManager::GetWiFiSignalStrength(const JsonObject& parameters, JsonObject& response)
+        uint32_t NetworkManager::GetWiFiSignalQuality(const JsonObject& parameters, JsonObject& response)
         {
             LOG_INPARAM();
             uint32_t rc = Core::ERROR_GENERAL;
             string ssid{};
             string strength{};
+            string noise{};
+            string snr{};
             Exchange::INetworkManager::WiFiSignalQuality quality{};
 
             if (_networkManager)
-                rc = _networkManager->GetWiFiSignalStrength(ssid, strength, quality);
+                rc = _networkManager->GetWiFiSignalQuality(ssid, strength, noise, snr, quality);
             else
                 rc = Core::ERROR_UNAVAILABLE;
 
             if (Core::ERROR_NONE == rc)
             {
                 Core::JSON::EnumType<Exchange::INetworkManager::WiFiSignalQuality> iquality(quality);
-                response["ssid"] = ssid;
+                response["ssid"]     = ssid;
+                response["quality"]  = iquality.Data();
+                response["snr"]      = snr;
                 response["strength"] = strength;
-                response["quality"] = iquality.Data();
+                response["noise"]    = noise;
             }
             returnJson(rc);
         }
@@ -1006,16 +1010,18 @@ namespace WPEFramework
             Notify(_T("onWiFiStateChange"), parameters);
         }
 
-        void NetworkManager::onWiFiSignalStrengthChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManager::onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             Core::JSON::EnumType<Exchange::INetworkManager::WiFiSignalQuality> iquality(quality);
             JsonObject parameters;
-            parameters["ssid"] = ssid;
+            parameters["ssid"]     = ssid;
+            parameters["quality"]  = iquality.Data();
+            parameters["snr"]      = snr;
             parameters["strength"] = strength;
-            parameters["quality"] = iquality.Data();
+            parameters["noise"]    = noise;
 
             LOG_INPARAM();
-            Notify(_T("onWiFiSignalStrengthChange"), parameters);
+            Notify(_T("onWiFiSignalQualityChange"), parameters);
         }
     }
 }

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -262,7 +262,7 @@ typedef struct _WiFiConnectedSSIDInfo
     char bssid[BSSID_BUFF];   /**< The the Basic Service Set ID (mac address). */
     char band[BUFF_MIN];      /**< The frequency band at which the client is conneted to. */
     int securityMode;         /**< Current WiFi Security Mode used for connection. */
-    int  frequency;                    /**< The Frequency wt which the client is connected to. */
+    int  frequency;           /**< The Frequency wt which the client is connected to. */
     float rate;               /**< The Physical data rate in Mbps */
     float noise;              /**< The average noise strength in dBm. */
     float signalStrength;     /**< The RSSI value in dBm. */
@@ -1357,13 +1357,15 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.ssid             = string(connectedSsid.ssid);
                 ssidInfo.bssid            = string(connectedSsid.bssid);
                 ssidInfo.security         = (WIFISecurityMode)mapToNewSecurityMode(connectedSsid.securityMode);
-                ssidInfo.strength         = to_string(connectedSsid.signalStrength);
-                ssidInfo.rate             = to_string(connectedSsid.rate);
+                ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
+                ssidInfo.rate             = to_string((int)connectedSsid.rate);
                 if(connectedSsid.noise <= 0 || connectedSsid.noise >= DEFAULT_NOISE)
-                    ssidInfo.noise        = to_string(connectedSsid.noise);
+                    ssidInfo.noise        = to_string((int)connectedSsid.noise);
                 else
                     ssidInfo.noise        = to_string(0);
-                ssidInfo.frequency        = to_string((double)connectedSsid.frequency/1000);
+
+                std::string freqStr       = to_string((double)connectedSsid.frequency/1000);
+                ssidInfo.frequency        = freqStr.substr(0, 5);
 
                 NMLOG_INFO ("GetConnectedSSID Success");
                 rc = Core::ERROR_NONE;
@@ -1376,7 +1378,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
         }
 
 #if 0
-        uint32_t NetworkManagerImplementation::GetWiFiSignalStrength(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
+        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
         {
             LOG_ENTRY_FUNCTION();
             uint32_t rc = Core::ERROR_RPC_CALL_FAILED;
@@ -1398,7 +1400,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                     floatStrength = 0.0;
 
                 strengthOut = static_cast<unsigned int>(floatStrength);
-                NMLOG_INFO ("WiFiSignalStrength in dB = %u",strengthOut);
+                NMLOG_INFO ("WiFiSignalQuality in dB = %u",strengthOut);
 
                 if (strengthOut == 0)
                 {
@@ -1423,12 +1425,12 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 }
 
                 strength = std::to_string(strengthOut);
-                NMLOG_INFO ("GetWiFiSignalStrength success");
+                NMLOG_INFO ("GetWiFiSignalQuality success");
                 rc = Core::ERROR_NONE;
             }
             else
             {
-                NMLOG_ERROR ("GetWiFiSignalStrength failed");
+                NMLOG_ERROR ("GetWiFiSignalQuality failed");
             }
             return rc;
         }

--- a/NetworkManagerStunClient.cpp
+++ b/NetworkManagerStunClient.cpp
@@ -370,7 +370,7 @@ bool client::bind(
         auto time_in_cache = std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now() - m_last_cache_time);
 
-        NMLOG_DEBUG("client::bind cache time=%lld", time_in_cache.count());
+        NMLOG_DEBUG("client::bind cache time=%lld", (long long int) time_in_cache.count());
 
         if(time_in_cache.count() < m_cache_timeout)
         {
@@ -668,7 +668,7 @@ std::unique_ptr<message> client::send_binding_request(std::chrono::milliseconds 
 std::unique_ptr<message> client::send_binding_request(sockaddr_storage const & addr, 
   std::chrono::milliseconds wait_time)
 {
-  NMLOG_DEBUG("sending binding request with wait time:%lld ms", wait_time.count());
+  NMLOG_DEBUG("sending binding request with wait time:%lld ms", (long long int) wait_time.count());
   this->create_udp_socket(addr.ss_family);
   std::unique_ptr<message> binding_request(message_factory::create_binding_request());
   std::unique_ptr<message> binding_response(this->send_message(addr, *binding_request, wait_time));

--- a/Tests/raspberrypi/NetworkManagerGdbusTest.cpp
+++ b/Tests/raspberrypi/NetworkManagerGdbusTest.cpp
@@ -63,9 +63,9 @@ namespace WPEFramework
         {
             NMLOG_INFO("calling 'ReportWiFiStateChange' cb");
         }
-        void NetworkManagerImplementation::ReportWiFiSignalStrengthChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
-            NMLOG_INFO("calling 'ReportWiFiSignalStrengthChange' cb");
+            NMLOG_INFO("calling 'ReportWiFiSignalQualityChange' cb");
         }
 
         NetworkManagerImplementation* _instance = nullptr;
@@ -275,7 +275,7 @@ int main()
             case 10: {
                 std::string ssid, signalStrength;
                 Exchange::INetworkManager::WiFiSignalQuality quality;
-                if (nmClient->getWiFiSignalStrength(ssid, signalStrength, quality)) {
+                if (nmClient->getWiFiSignalQuality(ssid, signalStrength, quality)) {
                     NMLOG_INFO("SSID: %s, Signal Strength: %s, Quality: %d", ssid.c_str(), signalStrength.c_str(), quality);
                 } else {
                     NMLOG_ERROR("Failed to get WiFi signal strength");

--- a/Tests/unit_test/test_WiFiSignalStrengthMonitor.cpp
+++ b/Tests/unit_test/test_WiFiSignalStrengthMonitor.cpp
@@ -16,7 +16,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 **/
-#include "WiFiSignalStrengthMonitor.h"
 #include "NetworkManagerImplementation.h"
 #include "NetworkManagerLogger.h"
 #include "INetworkManager.h"
@@ -36,7 +35,7 @@ namespace WPEFramework
    namespace Plugin
     {
         NetworkManagerImplementation* _instance = nullptr;
-        void NetworkManagerImplementation::ReportWiFiSignalStrengthChange(const string ssid, const string strength, const WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const WiFiSignalQuality quality)
         {
             return;
         }
@@ -48,20 +47,20 @@ namespace WPEFramework
     }
 }
 
-class WiFiSignalStrengthMonitorTest : public ::testing::Test {
+class WiFiSignalQualityMonitorTest : public ::testing::Test {
  protected:
-     WPEFramework::Plugin::WiFiSignalStrengthMonitor monitor;
+     WPEFramework::Plugin::WiFiSignalQualityMonitor monitor;
 };
 
-TEST_F(WiFiSignalStrengthMonitorTest, GetSignalData_Connected) {
+TEST_F(WiFiSignalQualityMonitorTest, GetSignalData_Connected) {
     std::string ssid = "TestSSID";
     Exchange::INetworkManager::WiFiSignalQuality quality;
     std::string strengthOut= "-55";
     monitor.getSignalData(ssid, quality, strengthOut);
 }
 
-TEST_F(WiFiSignalStrengthMonitorTest, StartWiFiSignalStrengthMonitor) {
-    monitor.startWiFiSignalStrengthMonitor(1);
+TEST_F(WiFiSignalQualityMonitorTest, StartWiFiSignalQualityMonitor) {
+    monitor.startWiFiSignalQualityMonitor(1);
 }
 
 int main(int argc, char **argv) {

--- a/docs/NetworkManagerPlugin.md
+++ b/docs/NetworkManagerPlugin.md
@@ -100,8 +100,8 @@ NetworkManager interface methods:
 | [GetConnectedSSID](#method.GetConnectedSSID) | Returns the connected SSID information |
 | [StartWPS](#method.StartWPS) | Initiates a connection using Wifi Protected Setup (WPS) |
 | [StopWPS](#method.StopWPS) | Cancels the in-progress WPS pairing operation |
-| [GetWiFiSignalStrength](#method.GetWiFiSignalStrength) | Get WiFiSignalStrength of connected SSID |
-| [GetSupportedsecurityModes](#method.GetSupportedsecurityModes) | Returns the Wifi security modes that the device supports |
+| [GetWiFiSignalQuality](#method.GetWiFiSignalQuality) | Get WiFi signal quality of currently connected SSID |
+| [GetSupportedSecurityModes](#method.GetSupportedSecurityModes) | Returns the Wifi security modes that the device supports |
 | [GetWifiState](#method.GetWifiState) | Returns the current Wifi State |
 
 <a name="method.SetLogLevel"></a>
@@ -1196,7 +1196,7 @@ Saves the SSID, passphrase, and security mode for upcoming and future sessions. 
 | params | object |  |
 | params.ssid | string | The WiFi SSID Name |
 | params.passphrase | string | The access point password |
-| params.security | integer | The security mode. See `getSupportedsecurityModes` |
+| params.security | integer | The security mode. See `GetSupportedSecurityModes` |
 
 ### Result
 
@@ -1217,7 +1217,7 @@ Saves the SSID, passphrase, and security mode for upcoming and future sessions. 
   "params": {
     "ssid": "myHomeSSID",
     "passphrase": "password",
-    "security": 6
+    "security": 2
   }
 }
 ```
@@ -1285,7 +1285,7 @@ Also see: [onWiFiStateChange](#event.onWiFiStateChange), [onAddressChange](#even
 <a name="method.WiFiConnect"></a>
 ## *WiFiConnect [<sup>method</sup>](#head.Methods)*
 
-Initiates request to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `AddToKnownSSIDs`.
+Initiates request to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. The security mode is decided based on the highest security mode provided by the SSID. Also when called with no arguments, this method attempts to connect to the saved SSID and password. See `AddToKnownSSIDs`.
 
 Also see: [onWiFiStateChange](#event.onWiFiStateChange)
 
@@ -1296,7 +1296,6 @@ Also see: [onWiFiStateChange](#event.onWiFiStateChange)
 | params | object |  |
 | params.ssid | string | The WiFi SSID Name |
 | params.passphrase | string | The access point password |
-| params?.security | integer | <sup>*(optional)*</sup> The security mode is decided based on the highest security mode provided by the SSID |
 | params?.ca_cert | string | <sup>*(optional)*</sup> The ca_cert to be used for EAP |
 | params?.client_cert | string | <sup>*(optional)*</sup> The client_cert to be used for EAP |
 | params?.private_key | string | <sup>*(optional)*</sup> The private_key to be used for EAP |
@@ -1327,7 +1326,6 @@ Also see: [onWiFiStateChange](#event.onWiFiStateChange)
   "params": {
     "ssid": "myHomeSSID",
     "passphrase": "password",
-    "security": 2,
     "ca_cert": "...",
     "client_cert": "...",
     "private_key": "...",
@@ -1413,10 +1411,10 @@ This method takes no parameters.
 | result.ssid | string | The WiFi SSID Name |
 | result.bssid | string | The BSSID of given SSID |
 | result.security | string | The security mode. See the `connect` method |
-| result.strength | string | The Signal RSSI value in dBm |
+| result.strength | string | The WiFi Signal RSSI value in dBm |
 | result.frequency | string | The supported frequency for this SSID in GHz |
 | result.rate | string | The physical data rate in Mbps |
-| result.noise | string | The average noise strength in dBm |
+| result.noise | string | The WiFi Signal Noise detected in dBm |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -1440,11 +1438,11 @@ This method takes no parameters.
   "result": {
     "ssid": "myHomeSSID",
     "bssid": "AA:BB:CC:DD:EE:FF",
-    "security": "5",
-    "strength": "-27.000000",
-    "frequency": "2.442000",
-    "rate": "144.000000",
-    "noise": "-121.000000",
+    "security": "2",
+    "strength": "-32",
+    "frequency": "2.4420",
+    "rate": "144",
+    "noise": "-106",
     "success": true
   }
 }
@@ -1546,18 +1544,18 @@ This method takes no parameters.
 }
 ```
 
-<a name="method.GetWiFiSignalStrength"></a>
-## *GetWiFiSignalStrength [<sup>method</sup>](#head.Methods)*
+<a name="method.GetWiFiSignalQuality"></a>
+## *GetWiFiSignalQuality [<sup>method</sup>](#head.Methods)*
 
-Get WiFiSignalStrength of connected SSID. The signal quality is identifed based on the Signal to Noise ratio which is calculated as SNR = rssi - noise. The possible states are
-* 'Excellent' : More than 40 dBm
-* 'Good' : 40 dBm to 25 dBm
-* 'Fair' : 25 dBm to 18 dBm
-* 'Weak' : 18 dBm to 0 dBm
+Get WiFi signal quality of currently connected SSID. The signal quality is identifed based on the Signal to Noise ratio which is calculated as SNR = rssi - noise. The possible states are
+* 'Excellent'    : More than 40 dBm
+* 'Good'         : 40 dBm to 25 dBm
+* 'Fair'         : 25 dBm to 18 dBm
+* 'Weak'         : 18 dBm to 0 dBm
 * 'Disconnected' : 0 dBm
 .
 
-Also see: [onWiFiSignalStrengthChange](#event.onWiFiSignalStrengthChange)
+Also see: [onWiFiSignalQualityChange](#event.onWiFiSignalQualityChange)
 
 ### Parameters
 
@@ -1569,8 +1567,10 @@ This method takes no parameters.
 | :-------- | :-------- | :-------- |
 | result | object |  |
 | result.ssid | string | The WiFi SSID Name |
-| result.strength | string | Signal to Noise Ratio(SNR) in dBm |
-| result.quality | string | Signal strength Quality |
+| result.quality | string | WiFi Quality based on Signal to Noise Ratio (SNR) |
+| result.snr | string | Signal to Noise Ratio(SNR) in dBm |
+| result.strength | string | The WiFi Signal RSSI value in dBm |
+| result.noise | string | The WiFi Signal Noise detected in dBm |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -1581,7 +1581,7 @@ This method takes no parameters.
 {
   "jsonrpc": "2.0",
   "id": 42,
-  "method": "org.rdk.NetworkManager.1.GetWiFiSignalStrength"
+  "method": "org.rdk.NetworkManager.1.GetWiFiSignalQuality"
 }
 ```
 
@@ -1593,15 +1593,17 @@ This method takes no parameters.
   "id": 42,
   "result": {
     "ssid": "myHomeSSID",
-    "strength": "-27.000000",
     "quality": "Excellent",
+    "snr": "74",
+    "strength": "-32",
+    "noise": "-106",
     "success": true
   }
 }
 ```
 
-<a name="method.GetSupportedsecurityModes"></a>
-## *GetSupportedsecurityModes [<sup>method</sup>](#head.Methods)*
+<a name="method.GetSupportedSecurityModes"></a>
+## *GetSupportedSecurityModes [<sup>method</sup>](#head.Methods)*
 
 Returns the Wifi security modes that the device supports.
 
@@ -1629,7 +1631,7 @@ This method takes no parameters.
 {
   "jsonrpc": "2.0",
   "id": 42,
-  "method": "org.rdk.NetworkManager.1.GetSupportedsecurityModes"
+  "method": "org.rdk.NetworkManager.1.GetSupportedSecurityModes"
 }
 ```
 
@@ -1727,7 +1729,7 @@ NetworkManager interface events:
 | [onInternetStatusChange](#event.onInternetStatusChange) | Triggered when internet connection state changed |
 | [onAvailableSSIDs](#event.onAvailableSSIDs) | Triggered when scan completes or when scan cancelled |
 | [onWiFiStateChange](#event.onWiFiStateChange) | Triggered when WIFI connection state get changed |
-| [onWiFiSignalStrengthChange](#event.onWiFiSignalStrengthChange) | Triggered when WIFI connection Signal Strength get changed |
+| [onWiFiSignalQualityChange](#event.onWiFiSignalQualityChange) | Triggered when WIFI Signal quality changed which is decided based on SNR value which is defined in `GetWiFiSignalQuality` |
 
 <a name="event.onInterfaceStateChange"></a>
 ## *onInterfaceStateChange [<sup>event</sup>](#head.Notifications)*
@@ -1863,8 +1865,8 @@ Triggered when scan completes or when scan cancelled.
 | params.ssids | array | On Available SSID's |
 | params.ssids[#] | object |  |
 | params.ssids[#].ssid | string | Discovered SSID |
-| params.ssids[#].security | integer | The security mode. See `getSupportedsecurityModes` |
-| params.ssids[#].strength | string | Signal to Noise Ratio(SNR) in dBm |
+| params.ssids[#].security | integer | The security mode. See `GetSupportedSecurityModes` |
+| params.ssids[#].strength | string | The WiFi Signal RSSI value in dBm |
 | params.ssids[#].frequency | string | The supported frequency for this SSID in GHz |
 
 ### Example
@@ -1877,9 +1879,9 @@ Triggered when scan completes or when scan cancelled.
     "ssids": [
       {
         "ssid": "myAP-2.4",
-        "security": 6,
-        "strength": "-27.000000",
-        "frequency": "2.442000"
+        "security": 2,
+        "strength": "-32",
+        "frequency": "2.4420"
       }
     ]
   }
@@ -1912,10 +1914,10 @@ Triggered when WIFI connection state get changed. The possible states are define
 }
 ```
 
-<a name="event.onWiFiSignalStrengthChange"></a>
-## *onWiFiSignalStrengthChange [<sup>event</sup>](#head.Notifications)*
+<a name="event.onWiFiSignalQualityChange"></a>
+## *onWiFiSignalQualityChange [<sup>event</sup>](#head.Notifications)*
 
-Triggered when WIFI connection Signal Strength get changed.
+Triggered when WIFI Signal quality changed which is decided based on SNR value which is defined in `GetWiFiSignalQuality`.
 
 ### Parameters
 
@@ -1923,19 +1925,23 @@ Triggered when WIFI connection Signal Strength get changed.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.ssid | string | The WiFi SSID Name |
-| params.strength | string | Signal to Noise Ratio(SNR) in dBm |
-| params.quality | string | Signal strength Quality |
+| params.quality | string | WiFi Quality based on Signal to Noise Ratio (SNR) |
+| params.snr | string | Signal to Noise Ratio(SNR) in dBm |
+| params.strength | string | The WiFi Signal RSSI value in dBm |
+| params.noise | string | The WiFi Signal Noise detected in dBm |
 
 ### Example
 
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "client.events.1.onWiFiSignalStrengthChange",
+  "method": "client.events.1.onWiFiSignalQualityChange",
   "params": {
     "ssid": "myHomeSSID",
-    "strength": "-27.000000",
-    "quality": "Excellent"
+    "quality": "Excellent",
+    "snr": "74",
+    "strength": "-32",
+    "noise": "-106"
   }
 }
 ```

--- a/gdbus/NetworkManagerGdbusClient.cpp
+++ b/gdbus/NetworkManagerGdbusClient.cpp
@@ -1833,7 +1833,7 @@ namespace WPEFramework
             return ret;
         }
 
-        bool NetworkManagerClient::getWiFiSignalStrength(string& ssid, string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality)
+        bool NetworkManagerClient::getWiFiSignalQuality(string& ssid, string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality)
         {
             Exchange::INetworkManager::WiFiSSIDInfo ssidInfo;
             float rssi = 0.0f;
@@ -1858,7 +1858,7 @@ namespace WPEFramework
                     floatSignalStrength = 0.0;
 
                 signalStrengthOut = static_cast<unsigned int>(floatSignalStrength);
-                NMLOG_INFO ("WiFiSignalStrength in dB = %u",signalStrengthOut);
+                NMLOG_INFO ("WiFiSignalQuality in dB = %u",signalStrengthOut);
 
                 if (signalStrengthOut == 0)
                 {

--- a/gdbus/NetworkManagerGdbusClient.h
+++ b/gdbus/NetworkManagerGdbusClient.h
@@ -62,7 +62,7 @@ namespace WPEFramework
                 bool wifiConnect(const Exchange::INetworkManager::WiFiConnectTo& ssidinfo);
                 bool wifiDisconnect();
                 bool getWifiState(Exchange::INetworkManager::WiFiState &state);
-                bool getWiFiSignalStrength(std::string& ssid, std::string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality);
+                bool getWiFiSignalQuality(std::string& ssid, std::string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality);
                 bool startWPS();
                 bool stopWPS();
 

--- a/gdbus/NetworkManagerGdbusProxy.cpp
+++ b/gdbus/NetworkManagerGdbusProxy.cpp
@@ -204,13 +204,13 @@ namespace WPEFramework
         }
 
 #if 0
-        uint32_t NetworkManagerImplementation::GetWiFiSignalStrength(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
+        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, WiFiSignalQuality& quality /* @out */)
         {
             uint32_t rc = Core::ERROR_GENERAL;
-            if(_nmGdbusClient->getWiFiSignalStrength(ssid, strength, quality))
+            if(_nmGdbusClient->getWiFiSignalQuality(ssid, strength, quality))
                 rc = Core::ERROR_NONE;
             else
-                NMLOG_ERROR("GetWiFiSignalStrength failed");
+                NMLOG_ERROR("GetWiFiSignalQuality failed");
             return rc;
         }
 #endif

--- a/gdbus/NetworkManagerGdbusUtils.cpp
+++ b/gdbus/NetworkManagerGdbusUtils.cpp
@@ -424,7 +424,8 @@ namespace WPEFramework
                 GnomeUtils::getCachedPropertyU(proxy, "Frequency", &freq);
                 GnomeUtils::getCachedPropertyU(proxy, "MaxBitrate", &bitrate);
 
-                wifiInfo.frequency = std::to_string((double)freq/1000);
+                std::string freqStr = std::to_string((double)freq/1000);
+                wifiInfo.frequency = freqStr.substr(0, 5);
                 wifiInfo.rate = std::to_string(bitrate);
                 wifiInfo.security = static_cast<Exchange::INetworkManager::WIFISecurityMode>(wifiSecurityModeFromApFlags(flags, wpaFlags, rsnFlags));
                 if(noise <= 0 || noise >= DEFAULT_NOISE)


### PR DESCRIPTION
Reason for change:
1. Updated `GetWiFiSignalQuality` method to include SNR & Noise
2. Updated `onWiFiSignalQualityChange` event to include SNR & Noise.
3. Updated the documentation
4. Added logging for the instantiation and exit Test Procedure: Verify the APIs
Risks: Medium
Signed-off-by: kamirt573_comcast <karunakaran_amirthalingam@cable.comcast.com>