### PR TITLE
RDKEMW-1928 - GetPrimaryInterface is returning false

### DIFF
--- a/NetworkManagerGnomeProxy.cpp
+++ b/NetworkManagerGnomeProxy.cpp
@@ -167,10 +167,13 @@ namespace WPEFramework
             if(ifacePtr == NULL)
             {
                 NMLOG_ERROR("nm_connection_get_interface_name is failed");
-                return Core::ERROR_GENERAL;
+                /* Temporary mitigation for nm_connection_get_interface_name failure */
+                if(m_ethConnected)
+                    interface = ethname;
+                else if(m_wlanConnected)
+                    interface = wifiname;
             }
 
-            interface = ifacePtr;
             m_defaultInterface = interface;
             if(interface != wifiname && interface != ethname)
             {


### PR DESCRIPTION
Reason for change: Temporary mitigation for GetPrimaryInterface failure
Test Procedure: Verify with curl commands
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>