### PR TITLE
RDKEMW-2006 - [RDKE][Xumo] Network reset taking more time and landing…

### DIFF
--- a/NetworkManagerImplementation.cpp
+++ b/NetworkManagerImplementation.cpp
@@ -687,9 +687,11 @@ namespace WPEFramework
             if (!m_isRunning) {
                 return; // No thread to stop
             }
-            std::lock_guard<std::mutex> lock(m_condVariableMutex);
-            m_stopThread = true;
-            m_condVariable.notify_one();
+            {
+                std::unique_lock<std::mutex> lock(m_condVariableMutex);
+                m_stopThread = true;
+                m_condVariable.notify_one();
+            }
             if (m_monitorThread.joinable()) {
                 m_monitorThread.join();
             }
@@ -813,7 +815,6 @@ namespace WPEFramework
                 std::string strength{};
                 std::string noise{};
                 std::string snr{};
-                std::unique_lock<std::mutex> lock(m_condVariableMutex);
                 Exchange::INetworkManager::WiFiSignalQuality newSignalQuality;
 
                 NMLOG_DEBUG("checking WiFi signal strength");
@@ -831,6 +832,7 @@ namespace WPEFramework
                     break; // Exit the loop
                 }
 
+                std::unique_lock<std::mutex> lock(m_condVariableMutex);
                 // Wait for the specified interval or until notified to stop
                 if (m_condVariable.wait_for(lock, std::chrono::seconds(interval), [this](){ return m_stopThread == true; }))
                 {


### PR DESCRIPTION
… on error page later

Reason for change: Moved the lock to a proper place in monitorThreadFunction() and also changed the lock to be present only for m_stopThread variable in stopWiFiSignalQualityMonitor.
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>