### PR TITLE
RDK-56182 - NetworkManager Thunder Plugin - Report WiFi SNR

### DIFF
--- a/NetworkManagerGnomeWIFI.cpp
+++ b/NetworkManagerGnomeWIFI.cpp
@@ -221,7 +221,7 @@ namespace WPEFramework
             wifiInfo.frequency = freqStr.substr(0, 5);
 
             wifiInfo.rate = std::to_string(bitrate);
-            if(noise <= 0 || noise >= DEFAULT_NOISE)
+            if(noise <= 0 && noise >= DEFAULT_NOISE)
                 wifiInfo.noise = std::to_string(noise);
             else
                 wifiInfo.noise = std::to_string(0);

--- a/NetworkManagerImplementation.cpp
+++ b/NetworkManagerImplementation.cpp
@@ -28,6 +28,7 @@ using namespace NetworkManagerLogger;
 #define CIDR_NETMASK_IP_LEN 32
 #define RSSID_COMMAND       "wpa_cli signal_poll"
 #define SSID_COMMAND        "wpa_cli status"
+#define BSS_COMMAND         "wpa_cli bss"
 
 namespace WPEFramework
 {
@@ -706,34 +707,12 @@ namespace WPEFramework
 
             std::string key, value;
             string noiseStr{};
-            string rssiStr{};
-            int16_t readRSSI = 0;
+            string snrStr{};
             int16_t readNoise = 0;
+            string bssid{};
             char buff[512] = {'\0'};
 
             FILE *fp = NULL;
-
-            /* Noise n RSSI */
-            fp = popen(RSSID_COMMAND, "r");
-            if (!fp)
-            {
-                NMLOG_ERROR("Failed in getting output from command %s",RSSID_COMMAND);
-                return Core::ERROR_RPC_CALL_FAILED;
-            }
-            while ((!feof(fp)) && (fgets(buff, sizeof (buff), fp) != NULL))
-            {
-                std::istringstream mystream(buff);
-                if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
-                    if (key == "RSSI") {
-                        rssiStr = value;
-                    }
-                    else if (key == "NOISE") {
-                        noiseStr = value;
-                    }
-                    if (!rssiStr.empty() && !noiseStr.empty())
-                        break;
-            }
-            pclose(fp);
 
             /* SSID */
             fp = popen(SSID_COMMAND, "r");
@@ -745,38 +724,63 @@ namespace WPEFramework
             while ((!feof(fp)) && (fgets(buff, sizeof (buff), fp) != NULL))                                                                     {
                 std::istringstream mystream(buff);
                 if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
-                    if (key == "ssid") {
-                        ssid = value;
+                    if (key == "bssid") {
+                        bssid = value;
                         break;
                     }
             }
             pclose(fp);
 
+            /* Noise n RSSI */
+            std::string bssCommand = std::string(BSS_COMMAND) + " " + bssid;
+            fp = popen(bssCommand.c_str(), "r");
+            if (!fp)
+            {
+                NMLOG_ERROR("Failed in getting output from command %s",RSSID_COMMAND);
+                return Core::ERROR_RPC_CALL_FAILED;
+            }
+            while ((!feof(fp)) && (fgets(buff, sizeof (buff), fp) != NULL))
+            {
+                std::istringstream mystream(buff);
+                if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
+                    if (key == "level") {
+                        strength = value;
+                    }
+                    else if (key == "noise") {
+                        noiseStr = value;
+                    }
+                    else if (key == "ssid") {
+                        ssid = value;
+                    }
+                    else if (key == "snr") {
+                        snrStr = value;
+                    }
+                    if (!strength.empty() && !noiseStr.empty() && !ssid.empty() && !snrStr.empty())
+                        break;
+            }
+            pclose(fp);
+
             /* NOTE: The std::stoi() will throw exception if the string input is empty; so set to 0 */
-            if (rssiStr.empty())
-                rssiStr = "0";
             if (noiseStr.empty())
                 noiseStr= "0";
+            if (snrStr.empty())
+                snrStr = "0";
 
-            readRSSI  = std::stoi(rssiStr);
             readNoise = std::stoi(noiseStr);
+            strengthOut = std::stoi(snrStr);
 
             /* Check the Noise is within range */
-            if(!(readNoise <= 0 || readNoise >= DEFAULT_NOISE))
+            if(!(readNoise <= 0 && readNoise >= DEFAULT_NOISE))
             {
                 NMLOG_WARNING("Received Noise (%d) from wifi driver is not valid", readNoise);
                 readNoise = 0;
             }
 
-            /* Calculate the SNR */
-            strengthOut = readRSSI - readNoise;
-
             /* Update the results */
-            strength = rssiStr;
             noise = noiseStr;
-            snr = std::to_string(strengthOut);
+            snr = snrStr;
 
-            NMLOG_INFO ("RSSI: %d dBm; Noise: %d dBm; SNR: %d dBm", readRSSI, readNoise, strengthOut);
+            NMLOG_INFO ("RSSI: %s dBm; Noise: %d dBm; SNR: %d dBm", strength.c_str(), readNoise, strengthOut);
 
             if (strengthOut == 0)
             {

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -1359,7 +1359,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.security         = (WIFISecurityMode)mapToNewSecurityMode(connectedSsid.securityMode);
                 ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
                 ssidInfo.rate             = to_string((int)connectedSsid.rate);
-                if(connectedSsid.noise <= 0 || connectedSsid.noise >= DEFAULT_NOISE)
+                if(connectedSsid.noise <= 0 && connectedSsid.noise >= DEFAULT_NOISE)
                     ssidInfo.noise        = to_string((int)connectedSsid.noise);
                 else
                     ssidInfo.noise        = to_string(0);

--- a/gdbus/NetworkManagerGdbusUtils.cpp
+++ b/gdbus/NetworkManagerGdbusUtils.cpp
@@ -428,7 +428,7 @@ namespace WPEFramework
                 wifiInfo.frequency = freqStr.substr(0, 5);
                 wifiInfo.rate = std::to_string(bitrate);
                 wifiInfo.security = static_cast<Exchange::INetworkManager::WIFISecurityMode>(wifiSecurityModeFromApFlags(flags, wpaFlags, rsnFlags));
-                if(noise <= 0 || noise >= DEFAULT_NOISE)
+                if(noise <= 0 && noise >= DEFAULT_NOISE)
                     wifiInfo.noise = std::to_string(noise);
                 else
                     wifiInfo.noise = std::to_string(0);


### PR DESCRIPTION
Reason for change: Modified the SNR value to read from the wpa_cli bss <bssid>
command
Test Procedure: check with the curl command for GetWiFiSignalQuality
Risks: low
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>