### PR TITLE
RDKTV-35857 - Device is connected to Wi-Fi but not connected to internet because of curl error 28

### DIFF
--- a/.github/workflows/rdk_unit_test.yml
+++ b/.github/workflows/rdk_unit_test.yml
@@ -2,9 +2,9 @@ name: rdk_unit_test
 
 on:
   push:
-    branches: [ main, develop, 'release/**']
+    branches: [ main, develop, 'release/**', 'hotfix/**']
   pull_request:
-    branches: [ main, develop, 'release/**']
+    branches: [ main, develop, 'release/**', 'hotfix/**']
 
 env:
   THUNDER_REF: "R4.4.1"

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -597,8 +597,8 @@ namespace WPEFramework
         std::thread ipv6thread;
 
         while (m_cmRunning) {
-            // Check if no interfaces are connected
-            if (_instance != nullptr && !_instance->m_ethConnected && !_instance->m_wlanConnected) {
+            if (nullptr == _instance)
+            {
                 NMLOG_DEBUG("no interface connected, no ccm check");
                 timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
                 m_InternetState = INTERNET_NOT_AVAILABLE;
@@ -607,6 +607,16 @@ namespace WPEFramework
                 currentInternetState = INTERNET_NOT_AVAILABLE;
                 if (InitialRetryCount == 0)
                     m_notify = true;
+                InitialRetryCount = 1;
+            }
+            // Check if no interfaces are connected
+            else if (_instance != nullptr && !_instance->m_ethConnected && !_instance->m_wlanConnected) {
+                NMLOG_DEBUG("no interface connected, no ccm check");
+                timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
+                m_InternetState = INTERNET_NOT_AVAILABLE;
+                m_Ipv4InternetState = INTERNET_NOT_AVAILABLE;
+                m_Ipv6InternetState = INTERNET_NOT_AVAILABLE;
+                currentInternetState = INTERNET_NOT_AVAILABLE;
                 InitialRetryCount = 1;
             }
             else if (m_switchToInitial)

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -357,7 +357,7 @@ namespace WPEFramework
                     }
                 }
                 else {
-                    NMLOG_ERROR("endpoint = <%s> curl error = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
+                    NMLOG_ERROR("endpoint = <%s> INTERNET_CONNECTIVITY_MONITORING_CURL_ERROR = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
                     curlErrorCode = static_cast<int>(msg->data.result);
                 }
                 http_responses.push_back(response_code);
@@ -621,7 +621,7 @@ namespace WPEFramework
             }
             else if (m_switchToInitial)
             {
-                NMLOG_INFO("Initial cm check - retry count %d - %s", InitialRetryCount, getInternetStateString(currentInternetState));
+                NMLOG_INFO("Initial connectivity check - index:%d current state:%s", InitialRetryCount, getInternetStateString(currentInternetState));
                 timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
 
                 // Lambda functions to check connectivity for IPv4 and IPv6

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -599,7 +599,7 @@ namespace WPEFramework
         while (m_cmRunning) {
             if (nullptr == _instance)
             {
-                NMLOG_DEBUG("Must be right from the constructor; becase the _instance is NULL");
+                NMLOG_DEBUG("Must be right from the constructor; because the _instance is NULL");
                 timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
                 m_InternetState = INTERNET_NOT_AVAILABLE;
                 m_Ipv4InternetState = INTERNET_NOT_AVAILABLE;

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -357,7 +357,7 @@ namespace WPEFramework
                     }
                 }
                 else {
-                    NMLOG_ERROR("endpoint = <%s> INTERNET_CONNECTIVITY_MONITORING_CURL_ERROR = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
+                    NMLOG_ERROR("endpoint = <%s> INTERNET_CONNECTIVITY_MONITORING curl error = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
                     curlErrorCode = static_cast<int>(msg->data.result);
                 }
                 http_responses.push_back(response_code);

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -615,6 +615,8 @@ namespace WPEFramework
                 m_Ipv4InternetState = INTERNET_NOT_AVAILABLE;
                 m_Ipv6InternetState = INTERNET_NOT_AVAILABLE;
                 currentInternetState = INTERNET_NOT_AVAILABLE;
+                if (InitialRetryCount == 0)
+                    m_notify = true;
                 InitialRetryCount = 1;
             }
             else if (m_switchToInitial)

--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -599,15 +599,13 @@ namespace WPEFramework
         while (m_cmRunning) {
             if (nullptr == _instance)
             {
-                NMLOG_DEBUG("no interface connected, no ccm check");
+                NMLOG_DEBUG("Must be right from the constructor; becase the _instance is NULL");
                 timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
                 m_InternetState = INTERNET_NOT_AVAILABLE;
                 m_Ipv4InternetState = INTERNET_NOT_AVAILABLE;
                 m_Ipv6InternetState = INTERNET_NOT_AVAILABLE;
                 currentInternetState = INTERNET_NOT_AVAILABLE;
-                if (InitialRetryCount == 0)
-                    m_notify = true;
-                InitialRetryCount = 1;
+                InitialRetryCount = 0;
             }
             // Check if no interfaces are connected
             else if (_instance != nullptr && !_instance->m_ethConnected && !_instance->m_wlanConnected) {

--- a/NetworkManagerImplementation.cpp
+++ b/NetworkManagerImplementation.cpp
@@ -575,6 +575,8 @@ namespace WPEFramework
                     m_ethConnected = false;
                 else if(interface == "wlan0")
                     m_wlanConnected = false;
+                m_IPv4Available = false;
+                m_IPv6Available = false;
                 connectivityMonitor.switchToInitialCheck();
             }
 
@@ -620,6 +622,10 @@ namespace WPEFramework
                 else if(interface == "wlan0")
                     m_wlanConnected = true;
 
+                if (0 == strcasecmp("IPv4", ipversion.c_str()))
+                    m_IPv4Available = true;
+                else if (0 == strcasecmp("IPv6", ipversion.c_str()))
+                    m_IPv6Available = true;
                 // FIXME : Availability of ip address for a given interface does not mean that its the default interface. This hardcoding will work for RDKProxy but not for Gnome.
                 if (m_ethConnected && m_wlanConnected)
                     m_defaultInterface = "eth0";

--- a/NetworkManagerImplementation.h
+++ b/NetworkManagerImplementation.h
@@ -277,6 +277,8 @@ namespace WPEFramework
                 std::atomic<bool> m_wlanConnected;
                 WiFiSignalStrengthMonitor m_wifiSignalMonitor;
                 mutable ConnectivityMonitor connectivityMonitor;
+                bool m_IPv4Available;
+                bool m_IPv6Available;
         };
     }
 }


### PR DESCRIPTION
Reason for change: Changed the initial monitoring logic to post the internet status change event even when we have single successful connect. Also changed the IPv4 and IPv6 thread start only when there is corresponding IPv4 and IPv6 are available
Test Procedure: Test and verified
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>