### PR TITLE
RDKTV-36020 : IP Address not cleared upon disconnect

### DIFF
--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -643,6 +643,7 @@ namespace WPEFramework
 
                 if(!_instance->m_IPv4Available && !_instance->m_IPv6Available)
                 {
+                    NMLOG_ERROR("NO_INTERNET due to NO IP Address");
                     timeoutInSec = NMCONNECTIVITY_MONITOR_MIN_INTERVAL;
                     m_InternetState = INTERNET_NOT_AVAILABLE;
                     m_Ipv4InternetState = INTERNET_NOT_AVAILABLE;


### PR DESCRIPTION
Reason for change: Added a log line to show no internet when both IPv4 and IPv6 are not available 
Test Procedure: Verify log getting printed when both IPv4 and IPv6 is not available Priority:P1
Risks: low
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>