### PR TITLE
RDKEMW-3249, RDKEMW-3191  Fix GetInterfaceState Reporting on Wi-Fi Only Devices & Enable NetworkManager DEBUG Logs via SetLogLevel(DEBUG)

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeEvents.cpp
+++ b/plugin/gnome/NetworkManagerGnomeEvents.cpp
@@ -54,12 +54,14 @@ namespace WPEFramework
             connectionTyp = nm_active_connection_get_connection_type(primaryConn);
             NMLOG_INFO("active connection - %s (%s)", activeConnId, connectionTyp);
 
-            if (0 == strncmp("802-3-ethernet", connectionTyp, sizeof("802-3-ethernet")))
+            if (0 == strncmp("802-3-ethernet", connectionTyp, sizeof("802-3-ethernet")) && string("eth0_missing") != nmUtils::ethIface())
                 newIface = nmUtils::ethIface();
-            else if(0 == strncmp("802-11-wireless", connectionTyp, sizeof("802-11-wireless")))
+            else if(0 == strncmp("802-11-wireless", connectionTyp, sizeof("802-11-wireless")) && string("wlan0_missing") != nmUtils::wlanIface())
                 newIface = nmUtils::wlanIface();
-            else
-                NMLOG_WARNING("active connection not an ethernet/wifi %s", connectionTyp);
+            else {
+                NMLOG_WARNING("Active connection not valid: Ethernet/WiFi ID: %s", connectionTyp);
+                return; // if not good don't report the evnet
+            }
 
             GnomeNetworkManagerEvents::onActiveInterfaceChangeCb(newIface);
         }
@@ -402,7 +404,7 @@ namespace WPEFramework
         g_signal_connect(nmEvents->client, "notify::" NM_CLIENT_STATE, G_CALLBACK (clientStateChangedCb),nmEvents);
         g_signal_connect(nmEvents->client, "notify::" NM_CLIENT_PRIMARY_CONNECTION, G_CALLBACK(primaryConnectionCb), nmEvents);
 
-       const GPtrArray *devices = nullptr;
+        const GPtrArray *devices = nullptr;
         devices = nm_client_get_devices(nmEvents->client);
 
         g_signal_connect(nmEvents->client, NM_CLIENT_DEVICE_ADDED, G_CALLBACK(deviceAddedCB), nmEvents);
@@ -615,6 +617,40 @@ namespace WPEFramework
         NMLOG_INFO("iface:%s - ipaddress:%s - %s - %s", iface.c_str(), ipAddress.c_str(), acquired?"acquired":"lost", isIPv6?"isIPv6":"isIPv4");
     }
 
+    bool GnomeNetworkManagerEvents::apToJsonObject(NMAccessPoint *ap, JsonObject& ssidObj)
+    {
+         GBytes *ssid = NULL;
+         int strength = 0;
+         std::string freq;
+         int security;
+         guint32 flags, wpaFlags, rsnFlags, apFreq;
+         if(ap == nullptr)
+             return false;
+         ssid = nm_access_point_get_ssid(ap);
+         if (ssid)
+         {
+             char *ssidStr = nullptr;
+             ssidStr = nm_utils_ssid_to_utf8((const guint8*)g_bytes_get_data(ssid, NULL), g_bytes_get_size(ssid));
+             string ssidString(ssidStr);
+             ssidObj["ssid"] = ssidString;
+             strength = nm_access_point_get_strength(ap);
+             apFreq   = nm_access_point_get_frequency(ap);
+             flags    = nm_access_point_get_flags(ap);
+             wpaFlags = nm_access_point_get_wpa_flags(ap);
+             rsnFlags = nm_access_point_get_rsn_flags(ap);
+             freq = nmUtils::wifiFrequencyFromAp(apFreq);
+             security = nmUtils::wifiSecurityModeFromAp(ssidString, flags, wpaFlags, rsnFlags, false);
+
+             ssidObj["security"] = security;
+             ssidObj["strength"] = nmUtils::convertPercentageToSignalStrengtStr(strength);
+             ssidObj["frequency"] = freq;
+             return true;
+         }
+         // else
+         //     NMLOG_DEBUG("hidden ssid found, bssid: %s", nm_access_point_get_bssid(ap));
+         return false;
+    }
+
     void GnomeNetworkManagerEvents::onAvailableSSIDsCb(NMDeviceWifi *wifiDevice, GParamSpec *pspec, gpointer userData)
     {
         if(!NM_IS_DEVICE_WIFI(wifiDevice))
@@ -629,7 +665,7 @@ namespace WPEFramework
         {
             JsonObject ssidObj;
             ap = static_cast<NMAccessPoint*>(accessPoints->pdata[i]);
-            if(nmUtils::apToJsonObject(ap, ssidObj))
+            if(GnomeNetworkManagerEvents::apToJsonObject(ap, ssidObj))
                 ssidList.Add(ssidObj);
         }
 

--- a/plugin/gnome/NetworkManagerGnomeEvents.h
+++ b/plugin/gnome/NetworkManagerGnomeEvents.h
@@ -57,6 +57,7 @@ namespace WPEFramework
 
     private:
         static void* networkMangerEventMonitor(void *arg);
+        static bool apToJsonObject(NMAccessPoint *ap, JsonObject& ssidObj);
         GnomeNetworkManagerEvents();
         ~GnomeNetworkManagerEvents();
         std::atomic<bool>isEventThrdActive = {false};

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -89,6 +89,7 @@ namespace WPEFramework
             nmEvent = GnomeNetworkManagerEvents::getInstance();
             nmEvent->startNetworkMangerEventMonitor();
             wifi = wifiManager::getInstance();
+            nmUtils::configureNetworkManagerDaemonLoglevel();
             return;
         }
 

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -42,6 +42,29 @@ namespace WPEFramework
             return;
         }
 
+        static NMDeviceState ifaceState(NMClient *client, const char* interface)
+        {
+            NMDeviceState deviceState = NM_DEVICE_STATE_UNKNOWN;
+            NMDevice *device = NULL;
+            if(client == NULL)
+                return deviceState;
+
+            if(string("eth0_missing") == interface || string("wlan0_missing") == interface)
+            {
+                NMLOG_DEBUG("interface %s is not valid", interface);
+                return deviceState;
+            }
+
+            device = nm_client_get_device_by_iface(client, interface);
+            if (device == NULL) {
+                NMLOG_FATAL("libnm doesn't have device corresponding to %s", interface);
+                return deviceState;
+            }
+
+            deviceState = nm_device_get_state(device);
+            return deviceState;
+        }
+
         void NetworkManagerImplementation::platform_init()
         {
             ::_instance = this;
@@ -56,7 +79,7 @@ namespace WPEFramework
             }
 
             nmUtils::getInterfacesName(); // get interface name form '/etc/device.proprties'
-            NMDeviceState ethState = nmUtils::ifaceState(client, nmUtils::ethIface());
+            NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
             if(ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING)
                 m_defaultInterface = nmUtils::ethIface();
             else
@@ -147,7 +170,7 @@ namespace WPEFramework
             activeConn = nm_client_get_primary_connection(client);
             if (activeConn == NULL) {
                 NMLOG_WARNING("no active activeConn Interface found");
-                NMDeviceState ethState = nmUtils::ifaceState(client, nmUtils::ethIface());
+                NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
                 /* if ethernet is connected but not completely activate then ethernet is taken as primary else wifi */
                 if(ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING)
                     m_defaultInterface = interface = ethname;
@@ -160,7 +183,7 @@ namespace WPEFramework
             if(remoteConn == NULL)
             {
                 NMLOG_WARNING("primary connection but remote connection error");
-                NMDeviceState ethState = nmUtils::ifaceState(client, nmUtils::ethIface());
+                NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
                 /* if ethernet is connected but not completely activate then ethernet is taken as primary else wifi */
                 if(ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING)
                     m_defaultInterface = interface = ethname;
@@ -391,7 +414,7 @@ namespace WPEFramework
                 return Core::ERROR_RPC_CALL_FAILED;
             }
 
-            if(interface.empty() || interface == "null")
+            if(interface.empty())
             {
                 if(Core::ERROR_NONE != GetPrimaryInterface(interface))
                 {

--- a/plugin/gnome/NetworkManagerGnomeUtils.cpp
+++ b/plugin/gnome/NetworkManagerGnomeUtils.cpp
@@ -249,5 +249,41 @@ namespace WPEFramework
             NMLOG_INFO("/etc/device.properties eth: %s, wlan: %s", m_ethifname.c_str(), m_wlanifname.c_str());
             return true;
         }
+
+        bool nmUtils::configureNetworkManagerDaemonLoglevel()
+        {
+            /* set networkmanager daemon log level based on current plugin log level */
+            const char* command = "nmcli general logging level TRACE domains ALL";
+            NetworkManagerLogger::LogLevel level;
+            NetworkManagerLogger::GetLevel(level);
+
+            if(NetworkManagerLogger::DEBUG_LEVEL != level)
+                return false;
+ 
+            // Execute the command using popen
+            FILE *pipe = popen(command, "r");
+
+            if (pipe == NULL) {
+                NMLOG_ERROR("popen failed %s ", command);
+                return false;
+            }
+    
+            // Close the pipe and retrieve the command's exit status
+            int status = pclose(pipe);
+            if (status == -1) {
+                perror("pclose failed");
+                return false;
+            }
+
+            // Extract the exit status from the status code
+            int exitCode = WEXITSTATUS(status);
+            if (exitCode == 0)
+                NMLOG_INFO("NetworkManager daemon log level changed ! logLevel: %d", level);
+            else
+                NMLOG_INFO(" '%s' failed with exit code %d.", command, exitCode);
+
+            return exitCode == 0;
+        }
+
     }   // Plugin
 }   // WPEFramework

--- a/plugin/gnome/NetworkManagerGnomeUtils.cpp
+++ b/plugin/gnome/NetworkManagerGnomeUtils.cpp
@@ -41,23 +41,6 @@ namespace WPEFramework
         const char* nmUtils::wlanIface() {return m_wlanifname.c_str();}
         const char* nmUtils::ethIface() {return m_ethifname.c_str();}
 
-        NMDeviceState nmUtils::ifaceState(NMClient *client, const char* interface)
-        {
-            NMDeviceState deviceState = NM_DEVICE_STATE_UNKNOWN;
-            NMDevice *device = NULL;
-            if(client == NULL)
-                return deviceState;
-
-            device = nm_client_get_device_by_iface(client, interface);
-            if (device == NULL) {
-                NMLOG_FATAL("libnm doesn't have device corresponding to %s", interface);
-                return deviceState;
-            }
-
-            deviceState = nm_device_get_state(device);
-            return deviceState;
-        }
-
         uint8_t nmUtils::wifiSecurityModeFromAp(const std::string& ssid, guint32 flags, guint32 wpaFlags, guint32 rsnFlags, bool doPrint)
         {
             uint8_t security = Exchange::INetworkManager::WIFI_SECURITY_NONE;
@@ -208,77 +191,8 @@ namespace WPEFramework
             return freq;
        }
 
-       bool nmUtils::apToJsonObject(NMAccessPoint *ap, JsonObject& ssidObj)
+       bool nmUtils::caseInsensitiveCompare(const std::string& str1, const std::string& str2)
        {
-            GBytes *ssid = NULL;
-            int strength = 0;
-            std::string freq;
-            int security;
-            guint32 flags, wpaFlags, rsnFlags, apFreq;
-            if(ap == nullptr)
-                return false;
-            ssid = nm_access_point_get_ssid(ap);
-            if (ssid)
-            {
-                char *ssidStr = nullptr;
-                ssidStr = nm_utils_ssid_to_utf8((const guint8*)g_bytes_get_data(ssid, NULL), g_bytes_get_size(ssid));
-                string ssidString(ssidStr);
-                ssidObj["ssid"] = ssidString;
-                strength = nm_access_point_get_strength(ap);
-                apFreq   = nm_access_point_get_frequency(ap);
-                flags    = nm_access_point_get_flags(ap);
-                wpaFlags = nm_access_point_get_wpa_flags(ap);
-                rsnFlags = nm_access_point_get_rsn_flags(ap);
-                freq = nmUtils::wifiFrequencyFromAp(apFreq);
-                security = nmUtils::wifiSecurityModeFromAp(ssidString, flags, wpaFlags, rsnFlags, false);
-
-                ssidObj["security"] = security;
-                ssidObj["strength"] = nmUtils::convertPercentageToSignalStrengtStr(strength);
-                ssidObj["frequency"] = freq;
-                return true;
-            }
-            // else
-            //     NMLOG_DEBUG("hidden ssid found, bssid: %s", nm_access_point_get_bssid(ap));
-            return false;
-       }
-
-        void nmUtils::printActiveSSIDsOnly(NMDeviceWifi *wifiDevice)
-        {
-            if(!NM_IS_DEVICE_WIFI(wifiDevice))
-            {
-                NMLOG_ERROR("Not a wifi object ");
-                return;
-            }
-            const GPtrArray *accessPointsArray = nm_device_wifi_get_access_points(wifiDevice);
-            for (guint i = 0; i < accessPointsArray->len; i++)
-            {
-                NMAccessPoint *ap = NULL;
-                GBytes *ssidGByte = NULL;
-                std::string ssid;
-
-                ap = (NMAccessPoint*)accessPointsArray->pdata[i];
-                ssidGByte = nm_access_point_get_ssid(ap);
-                if(ssidGByte)
-                {
-                    char* ssidStr = NULL;
-                    gsize len;
-                    const guint8 *ssidData = static_cast<const guint8 *>(g_bytes_get_data(ssidGByte, &len));
-                    ssidStr = nm_utils_ssid_to_utf8(ssidData, len);
-                    if(ssidStr != NULL) {
-                        std::string ssidTmp(ssidStr, len);
-                        ssid = ssidTmp;
-                    }
-                    else
-                        ssid = "---";
-                }
-                else
-                    ssid = "---";
-            
-                NMLOG_INFO("ssid: %s", ssid.c_str());
-            }
-        }
-
-        bool nmUtils::caseInsensitiveCompare(const std::string& str1, const std::string& str2) {
             std::string upperStr1 = str1;
             std::string upperStr2 = str2;
 
@@ -310,19 +224,26 @@ namespace WPEFramework
                     ethIfname = line.substr(line.find('=') + 1);
                     ethIfname.erase(ethIfname.find_last_not_of("\r\n\t") + 1);
                     ethIfname.erase(0, ethIfname.find_first_not_of("\r\n\t"));
+                    if(ethIfname.empty())
+                    {
+                        NMLOG_WARNING("ETHERNET_INTERFACE is empty in /etc/device.properties");
+                        ethIfname = "eth0_missing"; // means device doesnot have ethernet interface invalid name
+                    }
                 }
 
                 if (line.find("WIFI_INTERFACE=") != std::string::npos) {
                     wifiIfname = line.substr(line.find('=') + 1);
                     wifiIfname.erase(wifiIfname.find_last_not_of("\r\n\t") + 1);
                     wifiIfname.erase(0, wifiIfname.find_first_not_of("\r\n\t"));
+                    if(wifiIfname.empty())
+                    {
+                        NMLOG_WARNING("WIFI_INTERFACE is empty in /etc/device.properties");
+                        wifiIfname = "wlan0_missing"; // means device doesnot have wifi interface
+                    }
                 }
             }
             file.close();
-            if (ethIfname.empty() && wifiIfname.empty()) {
-                NMLOG_FATAL("Could not find any interface name in /etc/device.properties");
-                return false;
-            }
+
             m_wlanifname = wifiIfname;
             m_ethifname = ethIfname;
             NMLOG_INFO("/etc/device.properties eth: %s, wlan: %s", m_ethifname.c_str(), m_wlanifname.c_str());

--- a/plugin/gnome/NetworkManagerGnomeUtils.h
+++ b/plugin/gnome/NetworkManagerGnomeUtils.h
@@ -41,6 +41,7 @@ namespace WPEFramework
                static uint8_t wifiSecurityModeFromAp(const std::string& ssid, guint32 flags, guint32 wpaFlags, guint32 rsnFlags, bool doPrint = true);
                static std::string wifiFrequencyFromAp(guint32 apFreq);
                static std::string getSecurityModeString(guint32 flags, guint32 wpaFlags, guint32 rsnFlags);
+               static bool configureNetworkManagerDaemonLoglevel();
         };
     }
 }

--- a/plugin/gnome/NetworkManagerGnomeUtils.h
+++ b/plugin/gnome/NetworkManagerGnomeUtils.h
@@ -41,10 +41,6 @@ namespace WPEFramework
                static uint8_t wifiSecurityModeFromAp(const std::string& ssid, guint32 flags, guint32 wpaFlags, guint32 rsnFlags, bool doPrint = true);
                static std::string wifiFrequencyFromAp(guint32 apFreq);
                static std::string getSecurityModeString(guint32 flags, guint32 wpaFlags, guint32 rsnFlags);
-               static bool apToJsonObject(NMAccessPoint *ap, JsonObject& ssidObj);
-               static void printActiveSSIDsOnly(NMDeviceWifi *wifiDevice);
-               static NMDeviceState ifaceState(NMClient *client, const char* interface);
         };
-
     }
 }

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -1300,6 +1300,12 @@ namespace WPEFramework
             m_isSuccess = false;
             NMDevice *device = nullptr;
 
+            if(interface.empty() || (interface != nmUtils::ethIface() && interface != nmUtils::wlanIface()))
+            {
+                NMLOG_ERROR("Invalid interface name: %s", interface.c_str());
+                return false;
+            }
+
             if (!createClientNewConnection())
                 return false;
 
@@ -1396,6 +1402,12 @@ namespace WPEFramework
             NMDevice *device = NULL;
             const char *specObject = NULL;
 
+            if(interface.empty() || (interface != nmUtils::ethIface() && interface != nmUtils::wlanIface()))
+            {
+                NMLOG_ERROR("Invalid interface name: %s", interface.c_str());
+                return false;
+            }
+
             if (!createClientNewConnection())
                 return false;
 
@@ -1455,8 +1467,6 @@ namespace WPEFramework
                 }
                 connection = NM_CONNECTION(remoteConn);
             }
-            else
-                return false; // interface is not eth0 or wlan0
 
             if(connection == nullptr)
             {

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -221,10 +221,7 @@ namespace WPEFramework
             wifiInfo.frequency = freqStr.substr(0, 5);
 
             wifiInfo.rate = std::to_string(bitrate);
-            if(noise <= 0 && noise >= DEFAULT_NOISE)
-                wifiInfo.noise = std::to_string(noise);
-            else
-                wifiInfo.noise = std::to_string(0);
+            wifiInfo.noise = std::to_string(noise);
             NMLOG_DEBUG("bitrate : %s kbit/s", wifiInfo.rate.c_str());
             //TODO signal strenght to dBm
             wifiInfo.strength = std::string(nmUtils::convertPercentageToSignalStrengtStr(strength));


### PR DESCRIPTION
- RDKEMW-3249: GetInterfaceState API Returns Ethernet Enabled on Wi-Fi Only Devices
- RDKEMW-3191: Enabled NetworkManager DEBUG logs when SetLogLevel(DEBUG) Called