### PR TITLE
RDKTV-36195 - TV is taking 8-20 seconds to get stable internet connection after waking up from Deepsleep

### DIFF
--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -558,7 +558,6 @@ namespace WPEFramework
     bool ConnectivityMonitor::switchToInitialCheck()
     {
         m_switchToInitial = true;
-        m_notify = true; // m_notify internet state because some network state change may happen
         m_cmCv.notify_one();
         if(_instance != nullptr) {
             NMLOG_INFO("switching to initial check - eth %s - wlan %s",
@@ -596,7 +595,6 @@ namespace WPEFramework
         std::thread ipv4thread;
         std::thread ipv6thread;
         bool printIPNotAvailable = true;
-        int internalIPCheck = 0;
 
         while (m_cmRunning) {
             if (nullptr == _instance)
@@ -660,13 +658,7 @@ namespace WPEFramework
                         printIPNotAvailable = false;
                         m_notify = true;
                     }
-                    /* Very First time, it will check the IP States in 10th sec. IF  no IPs found, it will check every 15th sec */
-                    internalIPCheck++;
-                    if (internalIPCheck == NM_CONNECTIVITY_MONITOR_RETRY_COUNT)
-                    {
-                        internalIPCheck = 0;
-                        _instance->GetInitialConnectionState();
-                    }
+                    _instance->GetInitialConnectionState();
                 }
                 else
                     NMLOG_INFO("INTERNET_CONNECTIVITY_MONITORING_INITIAL_CHECK_ENTRY : Attempt#%d current state:%s", InitialRetryCount, getInternetStateString(currentInternetState));
@@ -727,8 +719,8 @@ namespace WPEFramework
                     m_switchToInitial = false;
                     m_notify = true;
                     InitialRetryCount = 0;
-                    IdealRetryCount = 0;
                 }
+                IdealRetryCount = 0;
             }
             // Ideal case monitoring
             else


### PR DESCRIPTION
Reason for change: Removed the m_notify in the switchToInitialCheck(). As it is leads to a unnecessary event posting, while the connectivityMonitorFunction() is in regular connectivity monitoring and switchToInitialCheck is triggered by ReportInterfaceStateChange() 
Test Procedure: Verify the deep sleep scenario for connectivity
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>