### PR TITLE
RDKTV-36415 - Device is taking 3-5min to connect the internet after waking from DS

### DIFF
--- a/NetworkManagerConnectivity.cpp
+++ b/NetworkManagerConnectivity.cpp
@@ -357,7 +357,11 @@ namespace WPEFramework
                     }
                 }
                 else {
-                    NMLOG_ERROR("endpoint = <%s> INTERNET_CONNECTIVITY_MONITORING_CURL_ERROR : curl error = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
+                    NMLOG_ERROR("INTERNET_CONNECTIVITY_MONITORING_CURL_ERROR : For endpoint = <%s> on (%s) got curl error = %d (%s)",
+                                                endpoint,
+                                                (IP_ADDRESS_V4 == ipversion) ?  "IPv4" : "IPv6",
+                                                msg->data.result,
+                                                curl_easy_strerror(msg->data.result));
                     curlErrorCode = static_cast<int>(msg->data.result);
                 }
                 http_responses.push_back(response_code);
@@ -658,11 +662,12 @@ namespace WPEFramework
                         printIPNotAvailable = false;
                         m_notify = true;
                     }
-                    _instance->GetInitialConnectionState();
                 }
-                else
-                    NMLOG_INFO("INTERNET_CONNECTIVITY_MONITORING_INITIAL_CHECK_ENTRY : Attempt#%d current state:%s", InitialRetryCount, getInternetStateString(currentInternetState));
 
+                if(!(_instance->m_IPv4Available && _instance->m_IPv6Available))
+                    _instance->GetInitialConnectionState();
+
+                NMLOG_INFO("INTERNET_CONNECTIVITY_MONITORING_INITIAL_CHECK_ENTRY : Attempt#%d current state:%s", InitialRetryCount, getInternetStateString(currentInternetState));
 
                 // Start threads for IPv4 and IPv6 checks
                 if(_instance->m_IPv4Available)
@@ -719,6 +724,7 @@ namespace WPEFramework
                     m_switchToInitial = false;
                     m_notify = true;
                     InitialRetryCount = 0;
+                    NMLOG_INFO("Let us monitor internet connectivity on %s address further.", (IP_ADDRESS_V4 == m_ipversion) ? "IPv4" : "IPv6");
                 }
                 IdealRetryCount = 0;
             }

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -675,9 +675,17 @@ namespace WPEFramework
                             {
                                 NMLOG_INFO("'%s' interface is connected", iface.name.c_str());
                                 ReportActiveInterfaceChange(iface.name, iface.name);
-                                std::string ipversion = {};
                                 Exchange::INetworkManager::IPAddress addr;
-                                rc = GetIPSettings(iface.name, ipversion, addr);
+                                rc = GetIPSettings(iface.name, "IPv4", addr);
+                                if (Core::ERROR_NONE == rc)
+                                {
+                                    if(!addr.ipaddress.empty()) {
+                                        NMLOG_INFO("'%s' interface have ip '%s'", iface.name.c_str(), addr.ipaddress.c_str());
+                                        ReportIPAddressChange(iface.name, addr.ipversion, addr.ipaddress, Exchange::INetworkManager::IP_ACQUIRED);
+                                    }
+                                }
+                                memset(&addr, 0, sizeof(addr));
+                                rc = GetIPSettings(iface.name, "IPv6", addr);
                                 if (Core::ERROR_NONE == rc)
                                 {
                                     if(!addr.ipaddress.empty()) {


### PR DESCRIPTION
Reason for change: To address the scenario of IPv6 lost after the device wakeup from deepsleep and has only IPv4. Currenlty, we are getting IPv6 as default IP Address which resulted in this issue. Enhanced the logic to get both IPv4 and IPv6 in GetInitialConnectionState() to address this issue.
Test Procedure: As mentioned in the jira ticket RDKTV-36415
Risks: Medium
Priority: P0
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>