### PR TITLE
RDKEMW-4100 - [RDKEMW][FOXTEL] [XioneUK] Process crashed = NetworkManager seen on after reboot

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -720,7 +720,12 @@ namespace WPEFramework
             }
             m_isRunning = true;
             m_stopThread = false;
-            m_monitorThread = std::thread(&NetworkManagerImplementation::monitorThreadFunction, this, interval);
+            try {
+                m_monitorThread = std::thread(&NetworkManagerImplementation::monitorThreadFunction, this, interval);
+                NMLOG_INFO("monitorThreadFunction thread creation successful");
+            } catch (const std::exception& err) {
+                NMLOG_INFO("monitorThreadFunction thread creation failed: %s\n", err.what());
+            }
         }
 
         void NetworkManagerImplementation::stopWiFiSignalQualityMonitor()


### PR DESCRIPTION
Reason for change: Added try catch to detect whether crash is happening in monitorThreadFunction function
Test Procedure: Check for the logs monitorThreadFunction 
Risks: Medium
Priority: P2