### PR TITLE
RDKTV-36771 - Hisense V2 devices take 5-10s more to get connected

### DIFF
--- a/NetworkManagerImplementation.cpp
+++ b/NetworkManagerImplementation.cpp
@@ -581,8 +581,12 @@ namespace WPEFramework
             }
 
             /* Only the Ethernet connection status is changing here. The WiFi status is updated in the WiFi state callback. */
-            if(Exchange::INetworkManager::INTERFACE_LINK_UP == state && interface == "eth0")
-                m_ethConnected = true;
+            if(Exchange::INetworkManager::INTERFACE_LINK_UP == state)
+            {
+                connectivityMonitor.switchToInitialCheck();
+                if(interface == "eth0")
+                    m_ethConnected = true;
+            }
 
             _notificationLock.Lock();
             NMLOG_INFO("Posting onInterfaceChange %s - %u", interface.c_str(), (unsigned)state);


### PR DESCRIPTION
Reason for change: Initiating the switchToInitialCheck() only when the interface is up so that we won't miss the onInternetStatusChange event 
Test Procedure: Check the timing to get connected to internet after waking from deep sleep
Risks: Medium
Priority: P1