### PR TITLE
RDKTV-36884 - Invalid onDefaultInterfaceChanged event is triggered

### DIFF
--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -545,9 +545,9 @@ namespace WPEFramework
                         oldInterface = e->oldInterface;
                         newInterface = e->newInterface;
                         NMLOG_INFO ("IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE %s :: %s..", oldInterface.c_str(), newInterface.c_str());
-                        if(oldInterface != "eth0" || oldInterface != "wlan0")
+                        if(oldInterface != "eth0" && oldInterface != "wlan0")
                             oldInterface = ""; /* assigning "null" if the interface is not eth0 or wlan0 */
-                        if(newInterface != "eth0" || newInterface != "wlan0")
+                        if(newInterface != "eth0" && newInterface != "wlan0")
                             newInterface = ""; /* assigning "null" if the interface is not eth0 or wlan0 */
 
                         ::_instance->ReportActiveInterfaceChange(oldInterface, newInterface);
@@ -674,7 +674,7 @@ namespace WPEFramework
                             if(iface.connected)
                             {
                                 NMLOG_INFO("'%s' interface is connected", iface.name.c_str());
-                                ReportActiveInterfaceChange(iface.name, iface.name);
+                                ReportActiveInterfaceChange("", iface.name);
                                 Exchange::INetworkManager::IPAddress addrv4;
                                 Exchange::INetworkManager::IPAddress addrv6;
                                 std::string ipversion = "IPv4";


### PR DESCRIPTION
Reason for change: Fixes for onDefaultInterfaceChange event is posted empty and it is posted when both old and new interface is same. 
Test Procedure: Check the wpeframework.log for the event posted. 
Risks: Medium