### PR TITLE
RDKEMW-5174 - LNF functionality not working with RDKE

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -662,7 +662,7 @@ namespace WPEFramework
                 if(wifi->activateKnownConnection(nmUtils::wlanIface(), _instance->m_lastConnectedSSID))
                     rc = Core::ERROR_NONE;
             }
-            else if(ssid.ssid.size() < 32)
+            else if(ssid.ssid.size() <= 32)
             {
                 if(wifi->wifiConnect(ssid))
                     rc = Core::ERROR_NONE;


### PR DESCRIPTION
Reason for change: Changed the allowed ssid size from lessthan 32 to lessthan or equal to 32 as LNF SSID size is 32 bytes Test Procedure: NA
Risks: Medium
Priority: P0