### PR TITLE
RDKTV-37227 - retrieveSSID API should return the Security Mode based on getsupportedsecuritymodes

### DIFF
--- a/legacy/LegacyWiFiManagerAPIs.cpp
+++ b/legacy/LegacyWiFiManagerAPIs.cpp
@@ -790,11 +790,11 @@ namespace WPEFramework
                 response["ssid"] = ssid;
                 //As enterprise data is not persisted, WPA_EAP mode is not considered here
                 if(security == "NONE")
-                    response["securityMode"] = JsonValue(Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_NONE);
+                    response["securityMode"] = JsonValue(NET_WIFI_SECURITY_NONE);
                 else if(security == "SAE")
-                    response["securityMode"] = JsonValue(Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_SAE);
+                    response["securityMode"] = JsonValue(NET_WIFI_SECURITY_WPA3_SAE);
                 else
-                    response["securityMode"] = JsonValue(Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_WPA_PSK);
+                    response["securityMode"] = JsonValue(NET_WIFI_SECURITY_WPA2_PSK_AES);
                                                     /* WPA3_PSK_AES has backward compatibility for PSK. So WPA-PSK is considered as default */
                 response["passphrase"] = passphrase;
                 response["success"] = true;


### PR DESCRIPTION
Reason for change: Changes the retieveSSID security mode return value as per legacy getsupportedsecuritymodes
Test Procedure: retrieveSSID curl
Risks: Medium
Priority: P1