### PR TITLE
RDKTV-37469, RDKTV-37468 - Increase in offline toaster markers

### DIFF
--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -663,21 +663,23 @@ namespace WPEFramework
             size_t interfaceCount = 0;
             Exchange::INetworkManager::InterfaceDetails tmpIface{};
 
-            while (_tmpInterfaces->Next(tmpIface))
-            {
-                if(tmpIface.enabled && tmpIface.connected)
-                {
-                    interfaceCount++;
-                }
-            }
-
             if (Core::ERROR_NONE == rc)
             {
                 if (_interfaces != nullptr)
                 {
+                    while (_tmpInterfaces->Next(tmpIface))
+                    {
+                        if(tmpIface.enabled && tmpIface.connected)
+                        {
+                            interfaceCount++;
+                        }
+                        NMLOG_INFO("GURU 1: interfaceCount = %d", interfaceCount);
+                    }
+
                     Exchange::INetworkManager::InterfaceDetails iface{};
                     while (_interfaces->Next(iface) == true)
                     {
+                        NMLOG_INFO("GURU 2: interfaceCount = %d", interfaceCount);
                         if((interfaceCount == 2 && "eth0" == iface.name) || interfaceCount == 1)
                         {
                             Core::JSON::EnumType<Exchange::INetworkManager::InterfaceType> type{iface.type};
@@ -714,6 +716,7 @@ namespace WPEFramework
                             }
                         }
                     }
+                    NMLOG_INFO("GURU 3: Outside while");
 
                     _interfaces->Release();
                 }

--- a/NetworkManagerRDKProxy.cpp
+++ b/NetworkManagerRDKProxy.cpp
@@ -673,13 +673,11 @@ namespace WPEFramework
                         {
                             interfaceCount++;
                         }
-                        NMLOG_INFO("GURU 1: interfaceCount = %d", interfaceCount);
                     }
-
+                    _tmpInterfaces->Reset(0);
                     Exchange::INetworkManager::InterfaceDetails iface{};
                     while (_interfaces->Next(iface) == true)
                     {
-                        NMLOG_INFO("GURU 2: interfaceCount = %d", interfaceCount);
                         if((interfaceCount == 2 && "eth0" == iface.name) || interfaceCount == 1)
                         {
                             Core::JSON::EnumType<Exchange::INetworkManager::InterfaceType> type{iface.type};
@@ -716,7 +714,6 @@ namespace WPEFramework
                             }
                         }
                     }
-                    NMLOG_INFO("GURU 3: Outside while");
 
                     _interfaces->Release();
                 }


### PR DESCRIPTION
Reason for change: The issue is because of the logic failure is in accessing the InterfaceList Iterator returned by the Thunder IIteratorType. Addressed the same by resetting the list with Reset() call. Also moved the interface count while loop, inside the return code and NULL pointer check to address the NetworkManager crash
Test Procedure: Deep sleep to wake up scenario
Priority:P1
Risks: Medium
Signed-off-by: Gururaaja E S R <Gururaja_ErodeSriranganRamlingham.comcast.com>