### PR TITLE
RDKTV-37469, RDKTV-37468 - Increase in offline toaster markers

### DIFF
--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -674,25 +674,22 @@ namespace WPEFramework
         {
             // check the connection state and post event
             Exchange::INetworkManager::IInterfaceDetailsIterator* _interfaces{};
-            Exchange::INetworkManager::IInterfaceDetailsIterator* _tmpInterfaces{};
             uint32_t rc = GetAvailableInterfaces(_interfaces);
-            _tmpInterfaces = _interfaces;
             size_t interfaceCount = 0;
-            Exchange::INetworkManager::InterfaceDetails tmpIface{};
-
-            while (_tmpInterfaces->Next(tmpIface))
-            {
-                if(tmpIface.enabled && tmpIface.connected)
-                {
-                    interfaceCount++;
-                }
-            }
+            Exchange::INetworkManager::InterfaceDetails iface{};
 
             if (Core::ERROR_NONE == rc)
             {
                 if (_interfaces != nullptr)
                 {
-                    Exchange::INetworkManager::InterfaceDetails iface{};
+                    while (_interfaces->Next(iface))
+                    {
+                        if(iface.enabled && iface.connected)
+                        {
+                            interfaceCount++;
+                        }
+                    }
+                    _interfaces->Reset(0);
                     while (_interfaces->Next(iface) == true)
                     {
                         if((interfaceCount == 2 && "eth0" == iface.name) || interfaceCount == 1)


### PR DESCRIPTION
Reason for change: The issue is because of the logic failure is in accessing the InterfaceList Iterator returned by the Thunder IIteratorType. Addressed the same by resetting the list with Reset() call. Also moved the interface count while loop inside the return code and NULL pointer check Test Procedure: Deep sleep to wake up scenario
Priority:P1
Risks: Medium