### PR TITLE
RDKEMW-6063 - OnWiFiStateChanged Event is not posted appropriately wlan0 LINK_UP

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeEvents.cpp
+++ b/plugin/gnome/NetworkManagerGnomeEvents.cpp
@@ -147,6 +147,7 @@ namespace WPEFramework
                     case NM_DEVICE_STATE_IP_CONFIG:
                         wifiState = "NM_DEVICE_STATE_IP_CONFIG";
                         GnomeNetworkManagerEvents::onInterfaceStateChangeCb(Exchange::INetworkManager::INTERFACE_LINK_UP, nmUtils::wlanIface());
+                        GnomeNetworkManagerEvents::onWIFIStateChanged(Exchange::INetworkManager::WIFI_STATE_CONNECTED);
                         break;
                     case NM_DEVICE_STATE_IP_CHECK:
                         wifiState = "NM_DEVICE_STATE_IP_CHECK";


### PR DESCRIPTION
Reason for change: Posting the WIFI connected event when we receive the state as NM_DEVICE_STATE_IP_CONFIG from gnome networkmanager so that we can avoid the delay in postin the events onWiFiStateChanged Test Procedure: Network reset with UI
Priority:P1
Risks: Medium