### PR TITLE
RDKTV-37660 - TVOffline marker seen after waking up due to Roam event

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -628,9 +628,11 @@ namespace WPEFramework
             /* Only the Ethernet connection status is changing here. The WiFi status is updated in the WiFi state callback. */
             if(Exchange::INetworkManager::INTERFACE_LINK_UP == state)
             {
-                connectivityMonitor.switchToInitialCheck();
                 if(interface == "eth0")
                     m_ethConnected.store(true);
+                else if(interface == "wlan0")
+                    m_wlanConnected = true;
+                connectivityMonitor.switchToInitialCheck();
             }
 
             _notificationLock.Lock();


### PR DESCRIPTION
Reason for change: The issue is happening because of the race condition happening between the 2 threads(connectivityMonitorFunction and the main thread in which switchToInitialCheck executes). Because of the race condition, switchToInitialCheck() was triggered before the m_wlanConnected was set to true. So the execution goes inside [else if (_instance != nullptr && !_instance->m_ethConnected && !_instance->m_wlanConnected)] and no event is actually posted as InitialRetryCount was already set to 1. Made changes to ReportInterfaceStateChange() to set m_wlanConnected to true when the interface is UP and then switchToInitialCheck() is triggered. 
Test Procedure: Deep sleep to wake up scenario
Priority:P1
Risks: Medium