### PR TITLE
RDKEMW-6097 - Removal of log GetIPSettings : ipversion error IPv4/IPv6

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -537,8 +537,6 @@ namespace WPEFramework
                     }
                 }
             }
-            else
-                NMLOG_WARNING("ipversion error IPv4/IPv6");
             if(result.ipaddress.empty())
             {
                 result.autoconfig = true;


### PR DESCRIPTION
Reason for change - Removal of unnecessary log to avoid log flooding