### PR TITLE
RDKEMW-7458 Connectivity monitor Thread crashed during Reboot

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -32,6 +32,7 @@ namespace WPEFramework
 {
     namespace Plugin
     {
+        extern NetworkManagerImplementation* _instance;
         SERVICE_REGISTRATION(NetworkManagerImplementation, NETWORKMANAGER_MAJOR_VERSION, NETWORKMANAGER_MINOR_VERSION, NETWORKMANAGER_PATCH_VERSION);
 
         NetworkManagerImplementation::NetworkManagerImplementation()
@@ -59,6 +60,8 @@ namespace WPEFramework
         NetworkManagerImplementation::~NetworkManagerImplementation()
         {
             NMLOG_INFO("NetworkManager Out-Of-Process Shutdown/Cleanup");
+            connectivityMonitor.stopConnectivityMonitor();
+            _instance = nullptr;
             if(m_registrationThread.joinable())
             {
                 m_registrationThread.join();


### PR DESCRIPTION
Reason for change: fix for connectivity monitor crash
Test Procedure: reboot test and verify the crash