### PR TITLE
RDKEMW-7459 : Clamp Network-Plugin Noise Value to Range [0 dBm to -96dBm]

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -849,11 +849,16 @@ namespace WPEFramework
             readNoise = std::stoi(noise);
             readSnr = std::stoi(snr);
 
-            /* Check the Noise is within range */
-            if(!(readNoise < 0 && readNoise >= DEFAULT_NOISE))
+            /* Check the Noise is within range between 0 and -96 dbm*/
+            if(readNoise >= 0 || readNoise < DEFAULT_NOISE)
             {
-                NMLOG_WARNING("Received Noise (%d) from wifi driver is not valid", readNoise);
-                noise = "0";
+                NMLOG_DEBUG("Received Noise (%d) from wifi driver is not valid", readNoise);
+                if (readNoise >= 0) {
+                    noise = std::to_string(0);
+                }
+                else if (readNoise < DEFAULT_NOISE) {
+                    noise = std::to_string(DEFAULT_NOISE);
+                }
             }
 
             /* mapping rssi value when the SNR value is not proper */

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -853,9 +853,9 @@ namespace WPEFramework
             readSnr = std::stoi(snr);
 
             /* Check the Noise is within range between 0 and -96 dbm*/
-            if(readNoise >= 0 || readNoise < DEFAULT_NOISE)
+            if((readNoise >= 0) || (readNoise < DEFAULT_NOISE))
             {
-                NMLOG_DEBUG("Received Noise (%d) from wifi driver is not valid", readNoise);
+                NMLOG_DEBUG("Received Noise (%d) from wifi driver is not valid; so clamping it", readNoise);
                 if (readNoise >= 0) {
                     noise = std::to_string(0);
                 }

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -35,7 +35,15 @@ using namespace std;
 #include "NetworkManagerConnectivity.h"
 #include "NetworkManagerStunClient.h"
 
-#define DEFAULT_NOISE                              -180
+/*
+ * Receiver thermal noise + BW factor + assumed noise figure (NF) (dB)
+ * for a 20MHz channel,
+ * = -174dBm/Hz + 10*log10(20MHz) + 5
+ * = -174 + 73 + 5 = -96dBm
+ * Even if the channel width increases, the noise value will be increases by 3 dBm; (ie -93 dBm). 
+ * So the minimum noise value cannot go beyond -96 dBm.
+ */
+#define DEFAULT_NOISE                              -96
 #define MAX_SNR_VALUE                              180
 
 #define DEFAULT_WIFI_SIGNAL_TEST_INTERVAL_SEC      60

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -1113,10 +1113,19 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.security         = (WIFISecurityMode)mapToNewSecurityMode(connectedSsid.securityMode);
                 ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
                 ssidInfo.rate             = to_string((int)connectedSsid.rate);
-                if(connectedSsid.noise <= 0 && connectedSsid.noise >= DEFAULT_NOISE)
-                    ssidInfo.noise        = to_string((int)connectedSsid.noise);
+
+                if((int)connectedSsid.noise >= 0 || (int)connectedSsid.noise < DEFAULT_NOISE)
+                {
+                    NMLOG_DEBUG("Received Noise (%f) from wifi driver is not valid", connectedSsid.noise);
+                    if (connectedSsid.noise >= 0) {
+                        ssidInfo.noise = std::to_string(0);
+                    }
+                    else if (connectedSsid.noise < DEFAULT_NOISE) {
+                        ssidInfo.noise = std::to_string(DEFAULT_NOISE);
+                    }
+                }
                 else
-                    ssidInfo.noise        = to_string(0);
+                    ssidInfo.noise = std::to_string((int)connectedSsid.noise);
 
                 std::string freqStr       = to_string((double)connectedSsid.frequency/1000);
                 ssidInfo.frequency        = freqStr.substr(0, 5);

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -1114,10 +1114,9 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
                 ssidInfo.rate             = to_string((int)connectedSsid.rate);
 
-                if(((int) connectedSsid.noise >= 0) ||
-                   ((int) connectedSsid.noise < DEFAULT_NOISE))
+                if(((int) connectedSsid.noise >= 0) || ((int) connectedSsid.noise < DEFAULT_NOISE))
                 {
-                    NMLOG_INFO ("Received Noise (%f) from wifi driver is not valid", connectedSsid.noise);
+                    NMLOG_DEBUG ("Received Noise (%f) from wifi driver is not valid; so clamping it", connectedSsid.noise);
                     if (connectedSsid.noise >= 0) {
                         ssidInfo.noise = std::to_string(0);
                     }

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -1114,9 +1114,10 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
                 ssidInfo.rate             = to_string((int)connectedSsid.rate);
 
-                if((int)connectedSsid.noise >= 0 || (int)connectedSsid.noise < DEFAULT_NOISE)
+                if(((int) connectedSsid.noise >= 0) ||
+                   ((int) connectedSsid.noise < DEFAULT_NOISE))
                 {
-                    NMLOG_DEBUG("Received Noise (%f) from wifi driver is not valid", connectedSsid.noise);
+                    NMLOG_INFO ("Received Noise (%f) from wifi driver is not valid", connectedSsid.noise);
                     if (connectedSsid.noise >= 0) {
                         ssidInfo.noise = std::to_string(0);
                     }

--- a/tests/l2Test/l2_test_rdkproxy.cpp
+++ b/tests/l2Test/l2_test_rdkproxy.cpp
@@ -979,7 +979,7 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_50)
     mockParam.data.getConnectedSSID.signalStrength = -30.00; // Example signal strength
     mockParam.data.getConnectedSSID.frequency = 2412; // Example frequency in MHz
     mockParam.data.getConnectedSSID.rate = 0; // Example rate
-    mockParam.data.getConnectedSSID.noise = -100; // Example noise level
+    mockParam.data.getConnectedSSID.noise = -50; // Example noise level
     strncpy(mockParam.data.getConnectedSSID.bssid, "AB:CD:EF:GH:IJ:KL", BSSID_BUFF - 1); // Example BSSID
     EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call(::testing::StrEq(IARM_BUS_NM_SRV_MGR_NAME),
                                                 ::testing::StrEq(IARM_BUS_WIFI_MGR_API_getConnectedSSID),
@@ -1365,7 +1365,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnected)
             if (tempFile) {
                 fputs("Selected interface 'wlan0'\n"
                     "ssid=dummySSID\n"
-                    "noise=-114\n"
+                    "noise=-117\n"
                     "level=-49\n"
                     "snr=65\n", tempFile);
                 rewind(tempFile);
@@ -1374,7 +1374,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnected)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":\"65\",\"strength\":\"-49\",\"noise\":\"-114\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":\"65\",\"strength\":\"-49\",\"noise\":\"-96\",\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedGood)
@@ -1402,7 +1402,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedGood)
             if (tempFile) {
                 fputs("Selected interface 'wlan0'\n"
                     "ssid=dummySSID\n"
-                    "noise=-114\n"
+                    "noise=-30\n"
                     "level=-90\n"
                     "snr=33\n", tempFile);
                 rewind(tempFile);
@@ -1411,7 +1411,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedGood)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Good\",\"snr\":\"33\",\"strength\":\"-90\",\"noise\":\"-114\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Good\",\"snr\":\"33\",\"strength\":\"-90\",\"noise\":\"-30\",\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedLowBad)
@@ -1439,7 +1439,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedLowBad)
             if (tempFile) {
                 fputs("Selected interface 'wlan0'\n"
                     "ssid=dummySSID\n"
-                    "noise=-114\n"
+                    "noise=9999\n"
                     "level=-120\n"
                     "snr=33\n", tempFile);
                 rewind(tempFile);
@@ -1448,7 +1448,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedLowBad)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Good\",\"snr\":\"33\",\"strength\":\"-120\",\"noise\":\"-114\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Good\",\"snr\":\"33\",\"strength\":\"-120\",\"noise\":\"0\",\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, Trace_Success_ipv4)

--- a/tests/l2Test/l2_test_rdkproxy.cpp
+++ b/tests/l2Test/l2_test_rdkproxy.cpp
@@ -920,6 +920,81 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success)
     EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"0\",\"success\":true}"));
 }
 
+TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_9999)
+{
+    IARM_Bus_WiFiSrvMgr_Param_t mockParam = {};
+    mockParam.status = true;
+    strncpy(mockParam.data.getConnectedSSID.ssid, "TestNetwork", SSID_SIZE - 1);
+    mockParam.data.getConnectedSSID.securityMode = NET_WIFI_SECURITY_WPA2_PSK_AES;
+    mockParam.data.getConnectedSSID.signalStrength = -30.00; // Example signal strength
+    mockParam.data.getConnectedSSID.frequency = 2412; // Example frequency in MHz
+    mockParam.data.getConnectedSSID.rate = 0; // Example rate
+    mockParam.data.getConnectedSSID.noise = 9999; // Example noise level
+    strncpy(mockParam.data.getConnectedSSID.bssid, "AB:CD:EF:GH:IJ:KL", BSSID_BUFF - 1); // Example BSSID
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call(::testing::StrEq(IARM_BUS_NM_SRV_MGR_NAME),
+                                                ::testing::StrEq(IARM_BUS_WIFI_MGR_API_getConnectedSSID),
+                                                ::testing::NotNull(), ::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::Invoke([&mockParam](const char*, const char*, void* arg, size_t) {
+                memcpy(arg, &mockParam, sizeof(mockParam));
+                return IARM_RESULT_SUCCESS;
+            })
+        ));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"0\",\"success\":true}"));
+}
+
+TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_100)
+{
+    IARM_Bus_WiFiSrvMgr_Param_t mockParam = {};
+    mockParam.status = true;
+    strncpy(mockParam.data.getConnectedSSID.ssid, "TestNetwork", SSID_SIZE - 1);
+    mockParam.data.getConnectedSSID.securityMode = NET_WIFI_SECURITY_WPA2_PSK_AES;
+    mockParam.data.getConnectedSSID.signalStrength = -30.00; // Example signal strength
+    mockParam.data.getConnectedSSID.frequency = 2412; // Example frequency in MHz
+    mockParam.data.getConnectedSSID.rate = 0; // Example rate
+    mockParam.data.getConnectedSSID.noise = -100; // Example noise level
+    strncpy(mockParam.data.getConnectedSSID.bssid, "AB:CD:EF:GH:IJ:KL", BSSID_BUFF - 1); // Example BSSID
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call(::testing::StrEq(IARM_BUS_NM_SRV_MGR_NAME),
+                                                ::testing::StrEq(IARM_BUS_WIFI_MGR_API_getConnectedSSID),
+                                                ::testing::NotNull(), ::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::Invoke([&mockParam](const char*, const char*, void* arg, size_t) {
+                memcpy(arg, &mockParam, sizeof(mockParam));
+                return IARM_RESULT_SUCCESS;
+            })
+        ));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"-96\",\"success\":true}"));
+}
+
+TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_50)
+{
+    IARM_Bus_WiFiSrvMgr_Param_t mockParam = {};
+    mockParam.status = true;
+    strncpy(mockParam.data.getConnectedSSID.ssid, "TestNetwork", SSID_SIZE - 1);
+    mockParam.data.getConnectedSSID.securityMode = NET_WIFI_SECURITY_WPA2_PSK_AES;
+    mockParam.data.getConnectedSSID.signalStrength = -30.00; // Example signal strength
+    mockParam.data.getConnectedSSID.frequency = 2412; // Example frequency in MHz
+    mockParam.data.getConnectedSSID.rate = 0; // Example rate
+    mockParam.data.getConnectedSSID.noise = -100; // Example noise level
+    strncpy(mockParam.data.getConnectedSSID.bssid, "AB:CD:EF:GH:IJ:KL", BSSID_BUFF - 1); // Example BSSID
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call(::testing::StrEq(IARM_BUS_NM_SRV_MGR_NAME),
+                                                ::testing::StrEq(IARM_BUS_WIFI_MGR_API_getConnectedSSID),
+                                                ::testing::NotNull(), ::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::Invoke([&mockParam](const char*, const char*, void* arg, size_t) {
+                memcpy(arg, &mockParam, sizeof(mockParam));
+                return IARM_RESULT_SUCCESS;
+            })
+        ));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"-50\",\"success\":true}"));
+}
+
 TEST_F(NetworkManagerTest, GetConnectedSSID_Failed)
 {
     EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call(::testing::StrEq(IARM_BUS_NM_SRV_MGR_NAME),


### PR DESCRIPTION
Reason for change: Clamp Network-Plugin Noise Value to Range [0 dBm to -96dBm]
some of the devices reporting a static noise value as (-117db)