### PR TITLE
RDKEMW-7736 : Comments Cleanup in NetworkManager Plugin (#218)

### DIFF
--- a/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
@@ -2022,8 +2022,6 @@ namespace WPEFramework
 
         bool NetworkManagerClient::wifiConnect(const Exchange::INetworkManager::WiFiConnectTo& connectInfo, bool iswpsAP)
         {
-            // TODO check sudo nmcli device wifi connect HomeNet password rafi@123
-            //            Error: Connection activation failed: Device disconnected by user or client error ?
             GVariantBuilder connBuilder;
             bool reuseConnection = false;
             deviceInfo deviceProp;


### PR DESCRIPTION
Reason for change: Removed the secrets stored as the comments 
Test Procedure: Verify the build is successful
Priority:P0
Risks: Medium