### PR TITLE
RDKEMW-7523 - Connect to Hidden SSID

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -853,12 +853,6 @@ namespace WPEFramework
                         return false;
                     }
                 }
-                else
-                {
-                    bool result = activateKnownConnection(nmUtils::wlanIface(), ssidInfo.ssid);
-                    deleteClientConnection();
-                    return result;
-                }
             }
             else
             {

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -799,26 +799,36 @@ namespace WPEFramework
             }
 
             AccessPoint = findMatchingSSID(ApList, ssidInfo.ssid);
-            if(AccessPoint == NULL) {
+            if(AccessPoint == NULL)
+            {
                 NMLOG_WARNING("SSID '%s' not found !", ssidInfo.ssid.c_str());
                 // if(_instance != nullptr)
                 //     _instance->ReportWiFiStateChange(Exchange::INetworkManager::WIFI_STATE_SSID_NOT_FOUND);
                 /* ssid not found in scan list so add to known ssid it will do a scanning and connect */
-                if(addToKnownSSIDs(ssidInfo))
+                if(ssidInfo.persist)
                 {
-                    NMLOG_DEBUG("Adding to known ssid '%s' ", ssidInfo.ssid.c_str());
-                    deleteClientConnection();
-                    return activateKnownConnection(nmUtils::wlanIface(), ssidInfo.ssid);
+                    if(addToKnownSSIDs(ssidInfo))
+                    {
+                        NMLOG_DEBUG("Adding to known ssid '%s' ", ssidInfo.ssid.c_str());
+                        deleteClientConnection();
+                        return activateKnownConnection(nmUtils::wlanIface(), ssidInfo.ssid);
+                    }
+                    else
+                    {
+                        deleteClientConnection();
+                        return false;
+                    }
                 }
-                deleteClientConnection();
-                return false;
+                else
+                {
+                    bool result = activateKnownConnection(nmUtils::wlanIface(), ssidInfo.ssid);
+                    deleteClientConnection();
+                    return result;
+                }
             }
-
-            getApInfo(AccessPoint, apinfo);
-
-            if(ssidInfo.security != apinfo.security)
+            else
             {
-                NMLOG_WARNING("user requested wifi security '%d' != AP supported security %d ", ssidInfo.security, apinfo.security);
+                getApInfo(AccessPoint, apinfo);
                 ssidInfo.security = apinfo.security;
             }
 

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -964,7 +964,7 @@ namespace WPEFramework
                     // This creates an in-memory only connection that won't persist
                     nm_client_add_connection2(m_client,
                                             connSettings,
-                                            (NMSettingsAddConnection2Flags)0, // No flags - don't save to disk
+                                            NM_SETTINGS_ADD_CONNECTION2_FLAG_IN_MEMORY,
                                             NULL, // no additional args
                                             TRUE, // ignore result
                                             NULL, // cancellable

--- a/tests/l2Test/libnm/l2_test_libnmproxyWifi.cpp
+++ b/tests/l2Test/libnm/l2_test_libnmproxyWifi.cpp
@@ -1280,10 +1280,8 @@ TEST_F(NetworkManagerWifiTest, WiFiConnect_with_no_access_point)
     EXPECT_CALL(*p_libnmWrapsImplMock, nm_device_get_iface(::testing::_))
         .WillRepeatedly(::testing::Return("wlan0"));
     EXPECT_CALL(*p_libnmWrapsImplMock, nm_device_get_state(::testing::_))
-        .WillOnce(::testing::Return(NM_DEVICE_STATE_ACTIVATED))
-        .WillOnce(::testing::Return(NM_DEVICE_STATE_ACTIVATED))
-        .WillOnce(::testing::Return(NM_DEVICE_STATE_ACTIVATED))
-        .WillOnce(::testing::Return(NM_DEVICE_STATE_UNMANAGED));
+        .Times(3)
+        .WillRepeatedly(::testing::Return(NM_DEVICE_STATE_ACTIVATED));
 
     EXPECT_CALL(*p_libnmWrapsImplMock, nm_device_wifi_get_last_scan(::testing::_))
         .WillOnce(::testing::Return(nm_utils_get_timestamp_msec() - 10));


### PR DESCRIPTION
Reason for change: To address the below points.
    1. When WIFIConnect requested and if the SSID is already in scan list, we must use security mode that is identified.
    2. When WIFIConnect requested and if the SSID is NOT in scan list, we must use security mode that is given.
    3. Regardless of 1 or 2, the SSID must be added to known-connections only when caller asked to persist.
Test Procedure: Check LNF ssid is getting saved or not, by connecting to LNF SSID using LostAndFound connectToPrivate curl command and rebooting the device
Priority:P1
Risks: Medium
Signed-off-by: Gururaaja ESR<Gururaja_ErodeSriranganRamlingham@comcast.com>