### PR TITLE
RDKEMW-7465: GetPrimaryInterface must return empty when WiFi is off

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -47,6 +47,8 @@ namespace WPEFramework
             m_publicIP = "";
             m_ethConnected.store(false);
             m_wlanConnected.store(false);
+            m_ethEnabled.store(false);
+            m_wlanEnabled.store(false);
 
             /* Set NetworkManager Out-Process name to be NWMgrPlugin */
             Core::ProcessInfo().Name("NWMgrPlugin");
@@ -683,9 +685,15 @@ namespace WPEFramework
                 // Switch the connectivity monitor to initial check
                 // if ipaddress is aquired means there should be interface connected
                 if(interface == "eth0")
+                {
                     m_ethConnected.store(true);
+                    m_ethEnabled.store(true);
+                }
                 else if(interface == "wlan0")
+                {
                     m_wlanConnected.store(true);
+                    m_wlanEnabled.store(true);
+                }
 
                 // FIXME : Availability of ip address for a given interface does not mean that its the default interface. This hardcoding will work for RDKProxy but not for Gnome.
                 if (m_ethConnected.load() && m_wlanConnected.load())

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -644,9 +644,15 @@ namespace WPEFramework
             if(Exchange::INetworkManager::INTERFACE_LINK_UP == state)
             {
                 if(interface == "eth0")
+                {
                     m_ethConnected.store(true);
+                    m_ethEnabled.store(true);
+                }
                 else if(interface == "wlan0")
+                {
                     m_wlanConnected.store(true);
+                    m_wlanEnabled.store(true);
+                }
                 // connectivityMonitor.switchToInitialCheck();
                 // FIXME : Availability of interface does not mean that it has internet connection, so not triggering connectivity monitor check here.
             }
@@ -665,9 +671,15 @@ namespace WPEFramework
             NMLOG_INFO("Posting onActiveInterfaceChange %s", currentActiveinterface.c_str());
 
             if(currentActiveinterface == "eth0")
+            {
                 m_ethConnected.store(true);
+                m_ethEnabled.store(true);
+            }
             else if (currentActiveinterface == "wlan0")
+            {
                 m_wlanConnected.store(true);
+                m_wlanEnabled.store(true);
+            }
 
             // FIXME : This could be the place to define `m_defaultInterface` to incoming `currentActiveinterface`.
             // m_defaultInterface = currentActiveinterface;

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -314,6 +314,8 @@ namespace WPEFramework
             public:
                 std::atomic<bool> m_ethConnected;
                 std::atomic<bool> m_wlanConnected;
+                std::atomic<bool> m_ethEnabled;
+                std::atomic<bool> m_wlanEnabled;
                 string m_defaultInterface;
                 std::string m_lastConnectedSSID;
                 mutable ConnectivityMonitor connectivityMonitor;

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -413,6 +413,8 @@ namespace WPEFramework
                     interface = nmUtils::ethIface();
                 else
                     interface = nmUtils::wlanIface(); // default is wifi
+                rc = Core::ERROR_NONE;
+                // TODO: if no proimary connection, should we return empty string? RDK V return empty string
             }
 
             m_defaultInterface = interface;

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -568,10 +568,11 @@ namespace WPEFramework
                     NMLOG_WARNING("default interface get failed");
                     return Core::ERROR_NONE;
                 }
+
                 if(interface.empty())
                 {
-                    NMLOG_DEBUG("default interface return empty default is wlan0");
-                    interface = wifiname;
+                    NMLOG_WARNING("default interface is empty, no active interface");
+                    return Core::ERROR_GENERAL;
                 }
             }
             else if(wifiname != interface && ethname != interface)

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -281,6 +281,7 @@ namespace WPEFramework
                 m_defaultInterface = nmUtils::wlanIface();
 
             NMLOG_INFO("default interface is %s",  m_defaultInterface.c_str());
+            // getInitialConnectionState function not called here, as event monitor will report the initial state
             nmEvent = GnomeNetworkManagerEvents::getInstance();
             nmEvent->startNetworkMangerEventMonitor();
             wifi = wifiManager::getInstance();
@@ -331,11 +332,13 @@ namespace WPEFramework
                             interface.type = INTERFACE_TYPE_WIFI;
                             interface.name = wifiname;
                             m_wlanConnected.store(interface.connected);
+                            m_wlanEnabled.store(interface.enabled);
                         }
-                        if(ifaceStr == ethname) {
+                        else if(ifaceStr == ethname) {
                             interface.type = INTERFACE_TYPE_ETHERNET;
                             interface.name = ethname;
                             m_ethConnected.store(interface.connected);
+                            m_ethEnabled.store(interface.enabled);
                         }
 
                         interfaceList.push_back(interface);
@@ -356,7 +359,6 @@ namespace WPEFramework
             GError *error = NULL;
             NMActiveConnection *activeConn = NULL;
             NMRemoteConnection *remoteConn = NULL;
-            std::string wifiname = nmUtils::wlanIface(), ethname = nmUtils::ethIface();
 
             if(client == nullptr)
             {
@@ -364,53 +366,55 @@ namespace WPEFramework
                 return Core::ERROR_GENERAL;
             }
 
+            if(!m_wlanEnabled.load() && !m_ethEnabled.load())
+            {
+                NMLOG_INFO("Both iface disabled state, returning no primary interface");
+                interface.clear();
+                m_defaultInterface = interface;
+                return Core::ERROR_NONE;
+            }
+
             activeConn = nm_client_get_primary_connection(client);
-            if (activeConn == NULL) {
-                NMLOG_WARNING("no active activeConn Interface found");
-                NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
-                /* if ethernet is connected but not completely activate then ethernet is taken as primary else wifi */
-                if(ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING)
-                    m_defaultInterface = interface = ethname;
-                else
-                    m_defaultInterface = interface = wifiname; // default is wifi
-                return Core::ERROR_NONE;
-            }
-
-            remoteConn = nm_active_connection_get_connection(activeConn);
-            if(remoteConn == NULL)
+            if (activeConn != NULL)
             {
-                NMLOG_WARNING("primary connection but remote connection error");
-                NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
-                /* if ethernet is connected but not completely activate then ethernet is taken as primary else wifi */
-                if(ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING)
-                    m_defaultInterface = interface = ethname;
-                else
-                    m_defaultInterface = interface = wifiname; // default is wifi
-                return Core::ERROR_NONE;
-            }
-
-            const char *ifacePtr = nm_connection_get_interface_name(NM_CONNECTION(remoteConn));
-            if(ifacePtr == NULL)
-            {
-                NMLOG_ERROR("nm_connection_get_interface_name is failed");
-                /* Temporary mitigation for nm_connection_get_interface_name failure */
-                if(m_ethConnected.load())
-                    interface = ethname;
-                else // default always wifi
-                    interface = wifiname;
-                rc = Core::ERROR_NONE;
-            }
-            else
-            {
-                interface = ifacePtr;
-                if(interface != wifiname && interface != ethname)
+                remoteConn = nm_active_connection_get_connection(activeConn);
+                if(remoteConn != NULL)
                 {
-                    NMLOG_ERROR("primary interface is not Ethernet or WiFi");
-                    interface.clear();
+                    const char *ifacePtr = nm_connection_get_interface_name(NM_CONNECTION(remoteConn));
+                    if(ifacePtr != NULL)
+                    {
+                        interface = ifacePtr;
+                        if(interface != nmUtils::wlanIface() && interface != nmUtils::ethIface())
+                        {
+                            NMLOG_WARNING("primary interface is not Ethernet or WiFi");
+                            interface.clear();
+                        }
+                        else
+                        {
+                            NMLOG_DEBUG("primary interface is %s", interface.c_str());
+                            rc = Core::ERROR_NONE;
+                        }
+                    }
+                    else
+                        NMLOG_WARNING("interface name is missing form connection");
                 }
                 else
-                    rc = Core::ERROR_NONE;
-            } 
+                    NMLOG_WARNING("primary connection but remote connection error");
+            }
+            else
+                NMLOG_WARNING("No primary connection");
+
+            if(rc != Core::ERROR_NONE)
+            {
+                // if no active connection or libnm error, choose the default interface based on the connection state 
+                NMDeviceState ethState = ifaceState(client, nmUtils::ethIface());
+                /* if ethernet is connected but not completely activate then ethernet is taken as primary else wifi */
+                if((ethState > NM_DEVICE_STATE_DISCONNECTED && ethState < NM_DEVICE_STATE_DEACTIVATING) || m_ethConnected.load())
+                    interface = nmUtils::ethIface();
+                else
+                    interface = nmUtils::wlanIface(); // default is wifi
+            }
+
             m_defaultInterface = interface;
             return rc;
         }
@@ -437,6 +441,12 @@ namespace WPEFramework
             }
 
             NMLOG_INFO("interface %s state: %s", interface.c_str(), enabled ? "enabled" : "disabled");
+            // update the interface global cache state
+            if(interface == nmUtils::wlanIface() && _instance != NULL)
+                _instance->m_wlanEnabled.store(enabled);
+            else if(interface == nmUtils::ethIface() && _instance != NULL)
+                _instance->m_ethEnabled.store(enabled);
+
             if(enabled)
             {
                 sleep(1); // wait for 1 sec to change the device state

--- a/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
@@ -102,7 +102,16 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_GENERAL;
             std::vector<Exchange::INetworkManager::InterfaceDetails> interfaceList;
             if(_nmGdbusClient->getAvailableInterfaces(interfaceList))
+            {
+                for (const auto& iface : interfaceList)
+                {
+                    if (iface.name == "eth0")
+                        m_ethEnabled.store(iface.enabled);
+                    else if (iface.name == "wlan0")
+                        m_wlanEnabled.store(iface.enabled);
+                }
                 rc = Core::ERROR_NONE;
+            }
             else
                 NMLOG_ERROR("GetAvailableInterfaces failed");
             using Implementation = RPC::IteratorType<Exchange::INetworkManager::IInterfaceDetailsIterator>;

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -575,6 +575,15 @@ namespace WPEFramework
             LOG_ENTRY_FUNCTION();
             uint32_t rc = Core::ERROR_RPC_CALL_FAILED;
             IARM_BUS_NetSrvMgr_DefaultRoute_t defaultRoute = {0};
+
+            if(!m_wlanEnabled.load() && !m_ethEnabled.load())
+            {
+                NMLOG_INFO("Both iface disabled state, returning no primary interface");
+                interface.clear();
+                m_defaultInterface = interface;
+                return Core::ERROR_NONE;
+            }
+
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getDefaultInterface, (void*)&defaultRoute, sizeof(defaultRoute)))
             {
                 NMLOG_INFO ("Call to %s for %s returned interface = %s, gateway = %s", IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getDefaultInterface, defaultRoute.interface, defaultRoute.gateway);

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -545,10 +545,12 @@ namespace WPEFramework
                         if ("eth0" == interfaceName) {
                             tmp.type = Exchange::INetworkManager::INTERFACE_TYPE_ETHERNET;
                             m_ethConnected.store(tmp.connected);
+                            m_ethEnabled.store(tmp.enabled);
                         }
                         else if ("wlan0" == interfaceName) {
                             tmp.type = Exchange::INetworkManager::INTERFACE_TYPE_WIFI;
                             m_wlanConnected.store(tmp.connected);
+                            m_wlanEnabled.store(tmp.enabled);
                         }
 
                         interfaceList.push_back(tmp);
@@ -608,7 +610,11 @@ namespace WPEFramework
             iarmData.persist = true;
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled, (void *)&iarmData, sizeof(iarmData)))
             {
-                NMLOG_INFO ("Call to %s for %s success", IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled);
+                NMLOG_INFO ("Call to %s for %s success", IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled);\
+                if(interface == "wlan0"  && _instance != NULL)
+                    _instance->m_wlanEnabled.store(enable);
+                else if(interface == "eth0" && _instance != NULL)
+                    _instance->m_ethEnabled.store(enable);
                 rc = Core::ERROR_NONE;
             }
             else


### PR DESCRIPTION
Reason for change: modify get primary Interface api 
Test Procedure: Verify in RDKE and RDK V devices
Priority: P1