### PR TITLE
RDKEMW-13401: Migration Device connects to Wi‑Fi instead of Ethernet

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -859,10 +859,16 @@ namespace WPEFramework
 
                 std::string connTypStr = connTyp;
                 NMLOG_DEBUG("connection id: %s, type: %s", connId != NULL ? connId : "NULL", connTypStr.c_str());
-                if(connTypStr == "802-11-wireless") {
+                // Store first connection only if it matches the interface type
+                if(iface == nmUtils::wlanIface() && connTypStr == "802-11-wireless") {
                     NMLOG_INFO("wifi conn found : %s", connId);
                     // if no known ssid given then use first wifi connection from list
                     // it usefule when bootup there will be no known ssid
+                    if(firstConnection == NULL)
+                        firstConnection = connection;
+                }
+                else if(iface == nmUtils::ethIface() && connTypStr == "802-3-ethernet") {
+                    NMLOG_INFO("ethernet conn found : %s", connId);
                     if(firstConnection == NULL)
                         firstConnection = connection;
                 }


### PR DESCRIPTION
Reason for Change: As the interface type is not checked before assigning the firstconnection. Firstconnection is getting assigned with a valid wifi connection when both ethernet and wifi are connected. So even when Wired connection is activated we end in activating Wifi connection. Added interface check to avoid this
Test Procedure: Migration test scenario
Priority: P1
Risks: Medium