### PR TITLE
RDKEMW-13769 : Always Enable WiFi upon Migration

### DIFF
--- a/plugin/gnome/systemd/gnome-networkmanager-migration.conf
+++ b/plugin/gnome/systemd/gnome-networkmanager-migration.conf
@@ -1,2 +1,5 @@
+[Unit]
+After=NM_Bootstrap.service
+
 [Service]
-ExecStartPre=/bin/sh -c '/lib/rdk/nm_interface_handler.sh'
+ExecStartPre=/lib/rdk/nm_interface_handler.sh


### PR DESCRIPTION
Updated to enable WiFi when BootType as BOOT_MIGRATION