### PR TITLE
RDKEMW-13125: Wi‑Fi in the picker are not ordered by signalstrength

### DIFF
--- a/definition/NetworkManager.json
+++ b/definition/NetworkManager.json
@@ -128,18 +128,18 @@
         },
         "strength":{
             "summary": "The WiFi Signal RSSI value in dBm",
-            "type": "string",
-            "example": "-32"
+            "type": "integer",
+            "example": -32
         },
         "noise":{
             "summary": "The WiFi Signal Noise detected in dBm",
-            "type": "string",
-            "example": "-96"
+            "type": "integer",
+            "example": -96
         },
         "snr":{
             "summary": "Signal to Noise Ratio(SNR) in dBm",
-            "type": "string",
-            "example": "74"
+            "type": "integer",
+            "example": 74
         },
         "quality":{
             "summary": "WiFi Quality based on Signal to Noise Ratio (SNR)",
@@ -148,8 +148,8 @@
         },
         "frequency":{
             "summary": "The supported frequency for this SSID in GHz",
-            "type": "string",
-            "example": "2.4420"
+            "type": "number",
+            "example": 2.4420
         },
         "errors": {
             "summary": "Error string of scan failure",
@@ -1109,8 +1109,8 @@
                     },
                     "rate":{
                         "summary": "The physical data rate in Mbps",
-                        "type": "string",
-                        "example": "144"
+                        "type": "integer",
+                        "example": 144
                     },
                     "noise":{
                         "$ref": "#/definitions/noise"

--- a/docs/NetworkManagerPlugin.md
+++ b/docs/NetworkManagerPlugin.md
@@ -1367,10 +1367,10 @@ This method takes no parameters.
 | result.ssid | string | The WiFi SSID Name |
 | result.bssid | string | The BSSID of given SSID |
 | result.security | string | The security mode. See the `connect` method |
-| result.strength | string | The WiFi Signal RSSI value in dBm |
-| result.frequency | string | The supported frequency for this SSID in GHz |
-| result.rate | string | The physical data rate in Mbps |
-| result.noise | string | The WiFi Signal Noise detected in dBm |
+| result.strength | integer | The WiFi Signal RSSI value in dBm |
+| result.frequency | number | The supported frequency for this SSID in GHz |
+| result.rate | integer | The physical data rate in Mbps |
+| result.noise | integer | The WiFi Signal Noise detected in dBm |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -1395,10 +1395,10 @@ This method takes no parameters.
     "ssid": "myHomeSSID",
     "bssid": "AA:BB:CC:DD:EE:FF",
     "security": "2",
-    "strength": "-32",
-    "frequency": "2.4420",
-    "rate": "144",
-    "noise": "-96",
+    "strength": -32,
+    "frequency": 2.442,
+    "rate": 144,
+    "noise": -96,
     "success": true
   }
 }
@@ -1524,9 +1524,9 @@ This method takes no parameters.
 | result | object |  |
 | result.ssid | string | The WiFi SSID Name |
 | result.quality | string | WiFi Quality based on Signal to Noise Ratio (SNR) |
-| result.snr | string | Signal to Noise Ratio(SNR) in dBm |
-| result.strength | string | The WiFi Signal RSSI value in dBm |
-| result.noise | string | The WiFi Signal Noise detected in dBm |
+| result.snr | integer | Signal to Noise Ratio(SNR) in dBm |
+| result.strength | integer | The WiFi Signal RSSI value in dBm |
+| result.noise | integer | The WiFi Signal Noise detected in dBm |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -1550,9 +1550,9 @@ This method takes no parameters.
   "result": {
     "ssid": "myHomeSSID",
     "quality": "Excellent",
-    "snr": "74",
-    "strength": "-32",
-    "noise": "-96",
+    "snr": 74,
+    "strength": -32,
+    "noise": -96,
     "success": true
   }
 }
@@ -1872,8 +1872,8 @@ Triggered when scan completes or when scan cancelled.
 | params.ssids[#] | object |  |
 | params.ssids[#].ssid | string | Discovered SSID |
 | params.ssids[#].security | integer | The security mode. See `GetSupportedSecurityModes` |
-| params.ssids[#].strength | string | The WiFi Signal RSSI value in dBm |
-| params.ssids[#].frequency | string | The supported frequency for this SSID in GHz |
+| params.ssids[#].strength | integer | The WiFi Signal RSSI value in dBm |
+| params.ssids[#].frequency | number | The supported frequency for this SSID in GHz |
 
 ### Example
 
@@ -1886,8 +1886,8 @@ Triggered when scan completes or when scan cancelled.
       {
         "ssid": "myAP-2.4",
         "security": 2,
-        "strength": "-32",
-        "frequency": "2.4420"
+        "strength": -32,
+        "frequency": 2.442
       }
     ]
   }
@@ -1932,9 +1932,9 @@ Triggered when WIFI Signal quality changed which is decided based on SNR value w
 | params | object |  |
 | params.ssid | string | The WiFi SSID Name |
 | params.quality | string | WiFi Quality based on Signal to Noise Ratio (SNR) |
-| params.snr | string | Signal to Noise Ratio(SNR) in dBm |
-| params.strength | string | The WiFi Signal RSSI value in dBm |
-| params.noise | string | The WiFi Signal Noise detected in dBm |
+| params.snr | integer | Signal to Noise Ratio(SNR) in dBm |
+| params.strength | integer | The WiFi Signal RSSI value in dBm |
+| params.noise | integer | The WiFi Signal Noise detected in dBm |
 
 ### Example
 
@@ -1945,9 +1945,9 @@ Triggered when WIFI Signal quality changed which is decided based on SNR value w
   "params": {
     "ssid": "myHomeSSID",
     "quality": "Excellent",
-    "snr": "74",
-    "strength": "-32",
-    "noise": "-96"
+    "snr": 74,
+    "strength": -32,
+    "noise": -96
   }
 }
 ```

--- a/interface/INetworkManager.h
+++ b/interface/INetworkManager.h
@@ -130,10 +130,10 @@ namespace WPEFramework
                     string             ssid;
                     string             bssid;
                     WIFISecurityMode   security;
-                    string             strength;
-                    string             frequency;
-                    string             rate;
-                    string             noise;
+                    int32_t            strength;
+                    double             frequency;
+                    int32_t            rate;
+                    int32_t            noise;
             };
 
             struct EXTERNAL WIFISecurityModeInfo {
@@ -252,7 +252,7 @@ namespace WPEFramework
             virtual uint32_t StartWPS(const WiFiWPS& method /* @in */, const string& pin /* @in */) = 0;
             virtual uint32_t StopWPS(void) = 0;
             virtual uint32_t GetWifiState(WiFiState &state /* @out */) = 0;
-            virtual uint32_t GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */) = 0;
+            virtual uint32_t GetWiFiSignalQuality(string& ssid /* @out */, int& strength /* @out */, int& noise /* @out */, int& snr /* @out */, WiFiSignalQuality& quality /* @out */) = 0;
             virtual uint32_t GetSupportedSecurityModes(ISecurityModeIterator*& modes/* @out */) const = 0;
 
             /* @brief Set the network manager plugin log level */
@@ -268,15 +268,16 @@ namespace WPEFramework
                 enum { ID = ID_NETWORKMANAGER_NOTIFICATION };
 
                 // Network Notifications that other processes can subscribe to
-                virtual void onInterfaceStateChange(const InterfaceState state /* @in */, const string interface /* @in */) = 0;
-                virtual void onActiveInterfaceChange(const string prevActiveInterface /* @in */, const string currentActiveInterface /* @in */) = 0;
-                virtual void onIPAddressChange(const string interface /* @in */, const string ipversion /* @in */, const string ipaddress /* @in */, const IPStatus status /* @in */) = 0;
-                virtual void onInternetStatusChange(const InternetStatus prevState /* @in */, const InternetStatus currState /* @in */, const string interface /* @in */) = 0;
+                virtual void onInterfaceStateChange(const InterfaceState state /* @in */, const string interface /* @in */){};
+                virtual void onActiveInterfaceChange(const string prevActiveInterface /* @in */, const string currentActiveInterface /* @in */){};
+                virtual void onIPAddressChange(const string interface /* @in */, const string ipversion /* @in */, const string ipaddress /* @in */, const IPStatus status /* @in */){};
+                virtual void onInternetStatusChange(const InternetStatus prevState /* @in */, const InternetStatus currState /* @in */, const string interface /* @in */){};
 
                 // WiFi Notifications that other processes can subscribe to
-                virtual void onAvailableSSIDs(const string jsonOfScanResults /* @in */) = 0;
-                virtual void onWiFiStateChange(const WiFiState state /* @in */) = 0;
-                virtual void onWiFiSignalQualityChange(const string ssid /* @in */, const string strength /* @in */, const string noise /* @in */, const string snr /* @in */, const WiFiSignalQuality quality /* @in */) = 0;
+                virtual void onAvailableSSIDs(const string jsonOfScanResults /* @in */){};
+                virtual void onWiFiStateChange(const WiFiState state /* @in */){};
+                virtual void onWiFiSignalQualityChange(const string ssid /* @in */, const int strength /* @in */, const int noise /* @in */, const int snr /* @in */, const WiFiSignalQuality quality /* @in */){};
+                virtual void onWiFiSignalQualityChange(const string ssid /* @in */, const string strength /* @in */, const string noise /* @in */, const string snr /* @in */, const WiFiSignalQuality quality /* @in */){};
             };
 
             // Allow other processes to register/unregister from our notifications

--- a/legacy/LegacyWiFiManagerAPIs.cpp
+++ b/legacy/LegacyWiFiManagerAPIs.cpp
@@ -400,11 +400,12 @@ namespace WPEFramework
             {
                 response["ssid"] = ssidInfo.ssid;
                 response["bssid"] = ssidInfo.bssid;
-                response["rate"] = ssidInfo.rate;
-                response["noise"] = ssidInfo.noise;
+                response["rate"] = to_string(ssidInfo.rate);
+                response["noise"] = to_string(ssidInfo.noise);
                 response["security"] = JsonValue(mapToLegacySecurityMode(ssidInfo.security));
-                response["signalStrength"] = ssidInfo.strength;
-                response["frequency"] = ssidInfo.frequency;
+                response["signalStrength"] = to_string(ssidInfo.strength);
+                std::string freqStr = to_string(ssidInfo.frequency);
+                response["frequency"] = freqStr.substr(0, 3);
             }
             returnJson(rc);
         }
@@ -911,10 +912,15 @@ namespace WPEFramework
             {
                 JsonObject object = ssids[i].Object();
                 uint32_t security = object["security"].Number();
-                object["security"] = mapToLegacySecurityMode(security);
-                ssidsUpdated.Add(object);
+                JsonObject newObject;
+                newObject["ssid"] = object["ssid"];
+                newObject["security"] = mapToLegacySecurityMode(security);
+                newObject["signalStrength"] = object["strength"];
+                newObject["frequency"] = object["frequency"];
+                ssidsUpdated.Add(newObject);
             }
             newParameters["ssids"] = ssidsUpdated;
+            newParameters["moreData"] = false;
 
             newParameters.ToString(json);
             NMLOG_INFO("Event with %d SSIDs as, %s", ssids.Length(), json.c_str());

--- a/plugin/NetworkManager.h
+++ b/plugin/NetworkManager.h
@@ -94,7 +94,7 @@ namespace WPEFramework
                     _parent.onWiFiStateChange(state);
                 }
 
-                void onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality) override
+                void onWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality) override
                 {
                     _parent.onWiFiSignalQualityChange(ssid, strength, noise, snr, quality);
                 }
@@ -262,7 +262,7 @@ namespace WPEFramework
             void onInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState, const string interface);
             void onAvailableSSIDs(const string jsonOfScanResults);
             void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state);
-            void onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
+            void onWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
 
         private:
             uint32_t _connectionId;

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -36,7 +36,6 @@ namespace WPEFramework
         SERVICE_REGISTRATION(NetworkManagerImplementation, NETWORKMANAGER_MAJOR_VERSION, NETWORKMANAGER_MINOR_VERSION, NETWORKMANAGER_PATCH_VERSION);
 
         NetworkManagerImplementation::NetworkManagerImplementation()
-            : _notificationCallbacks({})
         {
             /* Initialize STUN Endpoints */
             m_stunEndpoint = "stun.l.google.com";
@@ -81,7 +80,6 @@ namespace WPEFramework
                 m_processMonThread.join();
             }
         }
-
         /**
          * Register a notification callback
          */
@@ -839,7 +837,7 @@ namespace WPEFramework
         }
 
         /* The below implementation of GetWiFiSignalQuality is a temporary mitigation. Need to be revisited */
-        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */)
+        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, int& strength /* @out */, int& noise /* @out */, int& snr /* @out */, WiFiSignalQuality& quality /* @out */)
         {
             std::string key{}, value{}, bssid{}, band{};
             char buff[512] = {'\0'};
@@ -875,9 +873,9 @@ namespace WPEFramework
                 NMLOG_WARNING("WiFi is disconnected (BSSID is empty)");
                 quality = WiFiSignalQuality::WIFI_SIGNAL_DISCONNECTED;
                 ssid = "";
-                strength = "0";
-                noise = "0";
-                snr = "0";
+                strength = 0;
+                noise = 0;
+                snr = 0;
                 return Core::ERROR_NONE;
             }
 
@@ -889,38 +887,27 @@ namespace WPEFramework
                 return Core::ERROR_GENERAL;
             }
 
-			std::string linkSpeed;
+            // Collect raw values during parsing
+            std::string linkSpeed, rssiValue, noiseValue, avgRssiValue, freqValue;
             while ((!feof(fp)) && (fgets(buff, sizeof (buff), fp) != NULL))
             {
                 std::istringstream mystream(buff);
                 if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
                 {
                     if (key == "RSSI") {
-                        strength = value;
+                        rssiValue = value;
                     }
                     else if (key == "NOISE") {
-                        noise = value;
+                        noiseValue = value;
                     }
-                    else if (key == "AVG_RSSI") { // if RSSI is not available
-                        if (strength.empty())
-                            strength = value;
+                    else if (key == "AVG_RSSI") {
+                        avgRssiValue = value;
                     }
                     else if (key == "FREQUENCY")
                     {
-                        if (!value.empty())
-                        {
-                            int freq = std::stoi(value);
-                            if (freq >= 2400 && freq < 5000)
-                                band = "2.4GHz";
-                            else if (freq >= 5000 && freq < 6000)
-                                band = "5GHz";
-                            else if (freq >= 6000)
-                                band = "6GHz";
-                            else
-                                band = "not known";
-                        }
+                        freqValue = value;
                     }
-					else if (key == "LINKSPEED")
+		    else if (key == "LINKSPEED")
                     {
                         linkSpeed = value;
                     }
@@ -928,13 +915,25 @@ namespace WPEFramework
             }
             pclose(fp);
 
-            if (noise.empty())
-                noise = "0";
-            if (strength.empty())
-                strength = "0";
+            // Helper to safely convert string to int
+            auto toInt = [](const std::string& str, int defaultVal = 0) -> int {
+                return str.empty() ? defaultVal : std::stoi(str);
+            };
 
-            int16_t readRssi = std::stoi(strength);
-            int16_t readNoise = std::stoi(noise);
+            // Perform conversions - use RSSI if available, otherwise fallback to AVG_RSSI
+            strength = toInt(!rssiValue.empty() ? rssiValue : avgRssiValue, 0);
+            noise = toInt(noiseValue, 0);
+
+            // Determine band from frequency
+            if (!freqValue.empty()) {
+                int freq = std::stoi(freqValue);
+                band = (freq >= 2400 && freq < 5000) ? "2.4GHz" :
+                       (freq >= 5000 && freq < 6000) ? "5GHz" :
+                       (freq >= 6000) ? "6GHz" : "not known";
+            }
+
+            int16_t readRssi = strength;
+            int16_t readNoise = noise;
 
             /* Check the RSSI is within range between -10 and -100 dbm*/
             if (readRssi >= 0 || readRssi < -100) {
@@ -953,36 +952,36 @@ namespace WPEFramework
                 NMLOG_DEBUG("Received Noise (%d) from wifi driver is not valid; so clamping it", readNoise);
                 if (readNoise >= 0) {
                     readNoise = 0;
-                    noise = std::to_string(0);
+                    noise = 0;
                 }
                 else if (readNoise < DEFAULT_NOISE) {
                     readNoise = DEFAULT_NOISE;
-                    noise = std::to_string(DEFAULT_NOISE);
+                    noise = DEFAULT_NOISE;
                 }
             }
 
             /*Calculate SNR = RSSI - Noise */
             int16_t calculatedSnr = readRssi - readNoise;
-            snr = std::to_string(calculatedSnr);
+            snr = calculatedSnr;
 
             /* mapping rssi value when the SNR value is not proper */
             if(!(calculatedSnr > 0 && calculatedSnr <= MAX_SNR_VALUE))
             {
-                NMLOG_WARNING("calculated SNR (%d) is not valid; Lets map with RSSI (%s)", calculatedSnr, strength.c_str());
-                calculatedSnr = std::stoi(strength);
+                NMLOG_WARNING("calculated SNR (%d) is not valid; Lets map with RSSI (%d)", calculatedSnr, strength);
+                calculatedSnr = strength;
                 /* Take the absolute value */
                 calculatedSnr = (calculatedSnr < 0) ? -calculatedSnr : calculatedSnr;
 
-                snr = std::to_string(calculatedSnr);
+                snr = calculatedSnr;
             }
 
-			NMLOG_INFO("SSID:%s, BSSID:%s, Band:%s, RSSI:%s, Noise:%s, SNR:%s", ssid.c_str(), bssid.c_str(), band.c_str(), strength.c_str(), noise.c_str(), snr.c_str());
-            NMLOG_INFO("bssid=%s,ssid=%s,rssi=%s,phyrate=%s,noise=%s,Band=%s", bssid.c_str(), ssid.c_str(), strength.c_str(), linkSpeed.c_str(), noise.c_str(), band.c_str());
+            NMLOG_INFO("SSID:%s, BSSID:%s, Band:%s, RSSI:%d, Noise:%d, SNR:%d", ssid.c_str(), bssid.c_str(), band.c_str(), strength, noise, snr);
+            NMLOG_INFO("bssid=%s,ssid=%s,rssi=%d,phyrate=%s,noise=%d,Band=%s", bssid.c_str(), ssid.c_str(), strength, linkSpeed.c_str(), noise, band.c_str());
 
             if (calculatedSnr == 0)
             {
                 quality = WiFiSignalQuality::WIFI_SIGNAL_DISCONNECTED;
-                strength = "0";
+                strength = 0;
             }
             else if (calculatedSnr > 0 && calculatedSnr < NM_WIFI_SNR_THRESHOLD_FAIR)
             {
@@ -1062,9 +1061,9 @@ namespace WPEFramework
             while (true)
             {
                 std::string ssid{};
-                std::string strength{};
-                std::string noise{};
-                std::string snr{};
+                int strength = 0;
+                int noise = 0;
+                int snr = 0;
                 Exchange::INetworkManager::WiFiSignalQuality newSignalQuality;
 
                 GetWiFiSignalQuality(ssid, strength, noise, snr, newSignalQuality);
@@ -1114,10 +1113,10 @@ namespace WPEFramework
             _notificationLock.Unlock();
         }
 
-        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             _notificationLock.Lock();
-            NMLOG_INFO("Posting onWiFiSignalQualityChange %s", strength.c_str());
+            NMLOG_INFO("Posting onWiFiSignalQualityChange %d", strength);
             for (const auto callback : _notificationCallbacks) {
                 callback->onWiFiSignalQualityChange(ssid, strength, noise, snr, quality);
             }

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -36,7 +36,6 @@ namespace WPEFramework
         SERVICE_REGISTRATION(NetworkManagerImplementation, NETWORKMANAGER_MAJOR_VERSION, NETWORKMANAGER_MINOR_VERSION, NETWORKMANAGER_PATCH_VERSION);
 
         NetworkManagerImplementation::NetworkManagerImplementation()
-            : _notificationCallbacks({})
         {
             /* Initialize STUN Endpoints */
             m_stunEndpoint = "stun.l.google.com";
@@ -81,7 +80,6 @@ namespace WPEFramework
                 m_processMonThread.join();
             }
         }
-
         /**
          * Register a notification callback
          */
@@ -839,7 +837,7 @@ namespace WPEFramework
         }
 
         /* The below implementation of GetWiFiSignalQuality is a temporary mitigation. Need to be revisited */
-        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */)
+        uint32_t NetworkManagerImplementation::GetWiFiSignalQuality(string& ssid /* @out */, int& strength /* @out */, int& noise /* @out */, int& snr /* @out */, WiFiSignalQuality& quality /* @out */)
         {
             std::string key{}, value{}, bssid{}, band{};
             char buff[512] = {'\0'};
@@ -875,9 +873,9 @@ namespace WPEFramework
                 NMLOG_WARNING("WiFi is disconnected (BSSID is empty)");
                 quality = WiFiSignalQuality::WIFI_SIGNAL_DISCONNECTED;
                 ssid = "";
-                strength = "0";
-                noise = "0";
-                snr = "0";
+                strength = 0;
+                noise = 0;
+                snr = 0;
                 return Core::ERROR_NONE;
             }
 
@@ -889,38 +887,27 @@ namespace WPEFramework
                 return Core::ERROR_GENERAL;
             }
 
-			std::string linkSpeed;
+            // Collect raw values during parsing
+            std::string linkSpeed, rssiValue, noiseValue, avgRssiValue, freqValue;
             while ((!feof(fp)) && (fgets(buff, sizeof (buff), fp) != NULL))
             {
                 std::istringstream mystream(buff);
                 if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
                 {
                     if (key == "RSSI") {
-                        strength = value;
+                        rssiValue = value;
                     }
                     else if (key == "NOISE") {
-                        noise = value;
+                        noiseValue = value;
                     }
-                    else if (key == "AVG_RSSI") { // if RSSI is not available
-                        if (strength.empty())
-                            strength = value;
+                    else if (key == "AVG_RSSI") {
+                        avgRssiValue = value;
                     }
                     else if (key == "FREQUENCY")
                     {
-                        if (!value.empty())
-                        {
-                            int freq = std::stoi(value);
-                            if (freq >= 2400 && freq < 5000)
-                                band = "2.4GHz";
-                            else if (freq >= 5000 && freq < 6000)
-                                band = "5GHz";
-                            else if (freq >= 6000)
-                                band = "6GHz";
-                            else
-                                band = "not known";
-                        }
+                        freqValue = value;
                     }
-					else if (key == "LINKSPEED")
+		    else if (key == "LINKSPEED")
                     {
                         linkSpeed = value;
                     }
@@ -928,13 +915,25 @@ namespace WPEFramework
             }
             pclose(fp);
 
-            if (noise.empty())
-                noise = "0";
-            if (strength.empty())
-                strength = "0";
+            // Helper to safely convert string to int
+            auto toInt = [](const std::string& str, int defaultVal = 0) -> int {
+                return str.empty() ? defaultVal : std::stoi(str);
+            };
 
-            int16_t readRssi = std::stoi(strength);
-            int16_t readNoise = std::stoi(noise);
+            // Perform conversions - use RSSI if available, otherwise fallback to AVG_RSSI
+            strength = toInt(!rssiValue.empty() ? rssiValue : avgRssiValue, 0);
+            noise = toInt(noiseValue, 0);
+
+            // Determine band from frequency
+            if (!freqValue.empty()) {
+                int freq = std::stoi(freqValue);
+                band = (freq >= 2400 && freq < 5000) ? "2.4GHz" :
+                       (freq >= 5000 && freq < 6000) ? "5GHz" :
+                       (freq >= 6000) ? "6GHz" : "not known";
+            }
+
+            int16_t readRssi = strength;
+            int16_t readNoise = noise;
 
             /* Check the RSSI is within range between -10 and -100 dbm*/
             if (readRssi >= 0 || readRssi < -100) {
@@ -953,36 +952,36 @@ namespace WPEFramework
                 NMLOG_DEBUG("Received Noise (%d) from wifi driver is not valid; so clamping it", readNoise);
                 if (readNoise >= 0) {
                     readNoise = 0;
-                    noise = std::to_string(0);
+                    noise = 0;
                 }
                 else if (readNoise < DEFAULT_NOISE) {
                     readNoise = DEFAULT_NOISE;
-                    noise = std::to_string(DEFAULT_NOISE);
+                    noise = DEFAULT_NOISE;
                 }
             }
 
             /*Calculate SNR = RSSI - Noise */
             int16_t calculatedSnr = readRssi - readNoise;
-            snr = std::to_string(calculatedSnr);
+            snr = calculatedSnr;
 
             /* mapping rssi value when the SNR value is not proper */
             if(!(calculatedSnr > 0 && calculatedSnr <= MAX_SNR_VALUE))
             {
-                NMLOG_WARNING("calculated SNR (%d) is not valid; Lets map with RSSI (%s)", calculatedSnr, strength.c_str());
-                calculatedSnr = std::stoi(strength);
+                NMLOG_WARNING("calculated SNR (%d) is not valid; Lets map with RSSI (%d)", calculatedSnr, strength);
+                calculatedSnr = strength;
                 /* Take the absolute value */
                 calculatedSnr = (calculatedSnr < 0) ? -calculatedSnr : calculatedSnr;
 
-                snr = std::to_string(calculatedSnr);
+                snr = calculatedSnr;
             }
 
-			NMLOG_INFO("SSID:%s, BSSID:%s, Band:%s, RSSI:%s, Noise:%s, SNR:%s", ssid.c_str(), bssid.c_str(), band.c_str(), strength.c_str(), noise.c_str(), snr.c_str());
-            NMLOG_INFO("bssid=%s,ssid=%s,rssi=%s,phyrate=%s,noise=%s,Band=%s", bssid.c_str(), ssid.c_str(), strength.c_str(), linkSpeed.c_str(), noise.c_str(), band.c_str());
+            NMLOG_INFO("SSID:%s, BSSID:%s, Band:%s, RSSI:%d, Noise:%d, SNR:%d", ssid.c_str(), bssid.c_str(), band.c_str(), strength, noise, snr);
+            NMLOG_INFO("bssid=%s,ssid=%s,rssi=%d,phyrate=%s,noise=%d,Band=%s", bssid.c_str(), ssid.c_str(), strength, linkSpeed.c_str(), noise, band.c_str());
 
             if (calculatedSnr == 0)
             {
                 quality = WiFiSignalQuality::WIFI_SIGNAL_DISCONNECTED;
-                strength = "0";
+                strength = 0;
             }
             else if (calculatedSnr > 0 && calculatedSnr < NM_WIFI_SNR_THRESHOLD_FAIR)
             {
@@ -1062,9 +1061,9 @@ namespace WPEFramework
             while (true)
             {
                 std::string ssid{};
-                std::string strength{};
-                std::string noise{};
-                std::string snr{};
+                int strength = 0;
+                int noise = 0;
+                int snr = 0;
                 Exchange::INetworkManager::WiFiSignalQuality newSignalQuality;
 
                 GetWiFiSignalQuality(ssid, strength, noise, snr, newSignalQuality);
@@ -1114,12 +1113,21 @@ namespace WPEFramework
             _notificationLock.Unlock();
         }
 
-        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             _notificationLock.Lock();
-            NMLOG_INFO("Posting onWiFiSignalQualityChange %s", strength.c_str());
+            NMLOG_INFO("Posting onWiFiSignalQualityChange %d", strength);
             for (const auto callback : _notificationCallbacks) {
+                // Notify subscribers using the new (numeric) overload.
                 callback->onWiFiSignalQualityChange(ssid, strength, noise, snr, quality);
+
+                //Notify subscribers that still rely on the legacy (string)
+                callback->onWiFiSignalQualityChange(
+                    ssid,
+                    std::to_string(strength),
+                    std::to_string(noise),
+                    std::to_string(snr),
+                    std::to_string(static_cast<int>(quality)));
             }
             _notificationLock.Unlock();
         }

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -225,7 +225,7 @@ namespace WPEFramework
                 uint32_t StartWPS(const WiFiWPS& method /* @in */, const string& wps_pin /* @in */) override;
                 uint32_t StopWPS(void) override;
                 uint32_t GetWifiState(WiFiState &state) override;
-                uint32_t GetWiFiSignalQuality(string& ssid /* @out */, string& strength /* @out */, string& noise /* @out */, string& snr /* @out */, WiFiSignalQuality& quality /* @out */) override;
+                uint32_t GetWiFiSignalQuality(string& ssid /* @out */, int& strength /* @out */, int& noise /* @out */, int& snr /* @out */, WiFiSignalQuality& quality /* @out */) override;
 
                 uint32_t SetStunEndpoint (string const endpoint /* @in */, const uint32_t port /* @in */, const uint32_t bindTimeout /* @in */, const uint32_t cacheTimeout /* @in */) override;
                 uint32_t GetStunEndpoint (string &endpoint /* @out */, uint32_t& port /* @out */, uint32_t& bindTimeout /* @out */, uint32_t& cacheTimeout /* @out */) const override;
@@ -268,7 +268,7 @@ namespace WPEFramework
                 void ReportInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState, const string interface);
                 void ReportAvailableSSIDs(const JsonArray &arrayofWiFiScanResults);
                 void ReportWiFiStateChange(const Exchange::INetworkManager::WiFiState state);
-                void ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
+                void ReportWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
 
             private:
                 void platform_init(void);

--- a/plugin/NetworkManagerJsonRpc.cpp
+++ b/plugin/NetworkManagerJsonRpc.cpp
@@ -915,9 +915,9 @@ namespace WPEFramework
             LOG_INPARAM();
             uint32_t rc = Core::ERROR_GENERAL;
             string ssid{};
-            string strength{};
-            string noise{};
-            string snr{};
+            int strength = 0;
+            int noise = 0;
+            int snr = 0;
             Exchange::INetworkManager::WiFiSignalQuality quality{};
 
             if (_networkManager)
@@ -1044,7 +1044,7 @@ namespace WPEFramework
             Notify(_T("onWiFiStateChange"), parameters);
         }
 
-        void NetworkManager::onWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManager::onWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             Core::JSON::EnumType<Exchange::INetworkManager::WiFiSignalQuality> iquality(quality);
             JsonObject parameters;

--- a/plugin/gnome/NetworkManagerGnomeEvents.cpp
+++ b/plugin/gnome/NetworkManagerGnomeEvents.cpp
@@ -731,7 +731,7 @@ namespace WPEFramework
     {
          GBytes *ssid = NULL;
          int strength = 0;
-         std::string freq;
+         double freq;
          int security;
          guint32 flags, wpaFlags, rsnFlags, apFreq;
          if(ap == nullptr)
@@ -757,7 +757,7 @@ namespace WPEFramework
              security = nmUtils::wifiSecurityModeFromAp(ssidString, flags, wpaFlags, rsnFlags, false);
 
              ssidObj["security"] = security;
-             ssidObj["strength"] = nmUtils::convertPercentageToSignalStrengtStr(strength);
+             ssidObj["strength"] = nmUtils::convertPercentageToSignalStrength(strength);
              ssidObj["frequency"] = freq;
              return true;
          }

--- a/plugin/gnome/NetworkManagerGnomeUtils.cpp
+++ b/plugin/gnome/NetworkManagerGnomeUtils.cpp
@@ -66,10 +66,10 @@ namespace WPEFramework
         }
 
         // Function to convert percentage (0-100) to dBm string
-        const char* nmUtils::convertPercentageToSignalStrengtStr(int percentage) {
+        int nmUtils::convertPercentageToSignalStrength(int percentage) {
 
             if (percentage <= 0 || percentage > 100) {
-                return "";
+                return 0;
             }
 
            /*
@@ -85,9 +85,7 @@ namespace WPEFramework
             const int max_dBm = -30;
             const int min_dBm = -90;
             int dBm_value = max_dBm + ((min_dBm - max_dBm) * (100 - percentage)) / 100;
-            static char result[8]={0};
-            snprintf(result, sizeof(result), "%d", dBm_value);
-            return result;
+            return dBm_value;
         }
 
         std::string nmUtils::getSecurityModeString(guint32 flag, guint32 wpaFlags, guint32 rsnFlags)
@@ -180,17 +178,17 @@ namespace WPEFramework
             return securityStr;
         }
 
-       std::string nmUtils::wifiFrequencyFromAp(guint32 apFreq)
+       double nmUtils::wifiFrequencyFromAp(guint32 apFreq)
        {
-            std::string freq;
+            double freq;
             if (apFreq >= 2400 && apFreq < 5000)
-                freq = "2.4";
+                freq = 2.4;
             else if (apFreq >= 5000 && apFreq < 6000)
-                freq = "5";
+                freq = 5;
             else if (apFreq >= 6000)
-                freq = "6";
+                freq = 6;
             else
-                freq = "Not available";
+                freq = 0;
 
             return freq;
        }

--- a/plugin/gnome/NetworkManagerGnomeUtils.h
+++ b/plugin/gnome/NetworkManagerGnomeUtils.h
@@ -40,10 +40,10 @@ namespace WPEFramework
                static const char* wlanIface();
                static const char* ethIface();
                static const char* deviceHostname();
-               static const char* convertPercentageToSignalStrengtStr(int percentage);
+               static int convertPercentageToSignalStrength(int percentage);
                static bool caseInsensitiveCompare(const std::string& str1, const std::string& str2);
                static uint8_t wifiSecurityModeFromAp(const std::string& ssid, guint32 flags, guint32 wpaFlags, guint32 rsnFlags, bool doPrint = true);
-               static std::string wifiFrequencyFromAp(guint32 apFreq);
+               static double wifiFrequencyFromAp(guint32 apFreq);
                static std::string getSecurityModeString(guint32 flags, guint32 wpaFlags, guint32 rsnFlags);
                static bool setNetworkManagerlogLevelToTrace();
                static void setMarkerFile(const char* filename, bool unmark = false);

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -244,23 +244,22 @@ namespace WPEFramework
             }
 
             wifiInfo.bssid = (hwaddr != nullptr) ? hwaddr : "-----";
-            std::string freqStr = std::to_string((double)freq/1000);
-            wifiInfo.frequency = freqStr.substr(0, 5);
+            wifiInfo.frequency = ((double)freq/1000);
 
-            wifiInfo.rate = std::to_string(bitrate);
-            wifiInfo.noise = std::to_string(noise);
-            NMLOG_DEBUG("bitrate : %s kbit/s", wifiInfo.rate.c_str());
-            //TODO signal strenght to dBm
-            wifiInfo.strength = std::string(nmUtils::convertPercentageToSignalStrengtStr(strength));
+            wifiInfo.rate = bitrate;
+            wifiInfo.noise = noise;
+            NMLOG_DEBUG("bitrate : %d kbit/s", wifiInfo.rate);
+            //TODO signal strength to dBm
+            wifiInfo.strength = nmUtils::convertPercentageToSignalStrength(strength);
             wifiInfo.security = static_cast<Exchange::INetworkManager::WIFISecurityMode>(nmUtils::wifiSecurityModeFromAp(wifiInfo.ssid, flags, wpaFlags, rsnFlags, doPrint));
             if(doPrint)
             {
-                NMLOG_INFO("ssid: %s, frequency: %s, sterngth: %s, security: %u", wifiInfo.ssid.c_str(), wifiInfo.frequency.c_str(), wifiInfo.strength.c_str(), wifiInfo.security);
+                NMLOG_INFO("ssid: %s, frequency: %f, strength: %d, security: %u", wifiInfo.ssid.c_str(), wifiInfo.frequency, wifiInfo.strength, wifiInfo.security);
                 NMLOG_DEBUG("Mode: %s", mode == NM_802_11_MODE_ADHOC   ? "Ad-Hoc": mode == NM_802_11_MODE_INFRA ? "Infrastructure": "Unknown");
             }
             else
             {
-                NMLOG_DEBUG("ssid: %s, frequency: %s, sterngth: %s, security: %u", wifiInfo.ssid.c_str(), wifiInfo.frequency.c_str(), wifiInfo.strength.c_str(), wifiInfo.security);
+                NMLOG_DEBUG("ssid: %s, frequency: %f, strength: %d, security: %u", wifiInfo.ssid.c_str(), wifiInfo.frequency, wifiInfo.strength, wifiInfo.security);
                 NMLOG_DEBUG("Mode: %s", mode == NM_802_11_MODE_ADHOC   ? "Ad-Hoc": mode == NM_802_11_MODE_INFRA ? "Infrastructure": "Unknown");
             }
         }

--- a/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
@@ -2382,9 +2382,9 @@ namespace WPEFramework
             return ret;
         }
 
-        bool NetworkManagerClient::getWiFiSignalQuality(string& ssid, string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality)
+        bool NetworkManagerClient::getWiFiSignalQuality(string& ssid, int& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality)
         {
-            Exchange::INetworkManager::WiFiSSIDInfo ssidInfo;
+            Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
             float rssi = 0.0f;
             float noise = 0.0f;
             float floatSignalStrength = 0.0f;
@@ -2398,10 +2398,10 @@ namespace WPEFramework
             else
             {
                 ssid              = ssidInfo.ssid;
-                if (!ssidInfo.strength.empty())
-                    rssi          = std::stof(ssidInfo.strength.c_str());
-                if (!ssidInfo.noise.empty())
-                    noise         = std::stof(ssidInfo.noise.c_str());
+                if (ssidInfo.strength)
+                    rssi          = ssidInfo.strength;
+                if (ssidInfo.noise)
+                    noise         = ssidInfo.noise;
                 floatSignalStrength = (rssi - noise);
                 if (floatSignalStrength < 0)
                     floatSignalStrength = 0.0;
@@ -2412,7 +2412,7 @@ namespace WPEFramework
                 if (signalStrengthOut == 0)
                 {
                     quality = Exchange::INetworkManager::WiFiSignalQuality::WIFI_SIGNAL_DISCONNECTED;
-                    signalStrength = "0";
+                    signalStrength = 0;
                 }
                 else if (signalStrengthOut > 0 && signalStrengthOut < NM_WIFI_SNR_THRESHOLD_FAIR)
                 {
@@ -2431,9 +2431,9 @@ namespace WPEFramework
                     quality = Exchange::INetworkManager::WiFiSignalQuality::WIFI_SIGNAL_EXCELLENT;
                 }
 
-                signalStrength = std::to_string(signalStrengthOut);
+                signalStrength = signalStrengthOut;
 
-                NMLOG_INFO("strength success %s dBm", signalStrength.c_str());
+                NMLOG_INFO("strength success %d dBm", signalStrength);
             }
 
             return true;

--- a/plugin/gnome/gdbus/NetworkManagerGdbusClient.h
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusClient.h
@@ -69,7 +69,7 @@ namespace WPEFramework
                 bool wifiDisconnect();
                 bool activateKnownConnection(const std::string& interface, const std::string& knownConnectionID = "");
                 bool getWifiState(Exchange::INetworkManager::WiFiState &state);
-                bool getWiFiSignalQuality(std::string& ssid, std::string& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality);
+                bool getWiFiSignalQuality(std::string& ssid, int& signalStrength, Exchange::INetworkManager::WiFiSignalQuality& quality);
                 bool startWPS();
                 bool stopWPS();
                 bool setHostname(const std::string& hostname);

--- a/plugin/gnome/gdbus/NetworkManagerGdbusUtils.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusUtils.cpp
@@ -393,7 +393,7 @@ namespace WPEFramework
                     return false;
                 }
                 g_variant_get(result, "y", &strength);
-                wifiInfo.strength = GnomeUtils::convertPercentageToSignalStrengtStr((int)strength);
+                wifiInfo.strength = GnomeUtils::convertPercentageToSignalStrength((int)strength);
                 g_variant_unref(result);
 
                 GnomeUtils::getCachedPropertyU(proxy, "Flags", &flags);
@@ -403,14 +403,13 @@ namespace WPEFramework
                 GnomeUtils::getCachedPropertyU(proxy, "Frequency", &freq);
                 GnomeUtils::getCachedPropertyU(proxy, "MaxBitrate", &bitrate);
 
-                std::string freqStr = std::to_string((double)freq/1000);
-                wifiInfo.frequency = freqStr.substr(0, 5);
-                wifiInfo.rate = std::to_string(bitrate);
+                wifiInfo.frequency = ((double)freq/1000);
+                wifiInfo.rate = bitrate;
                 wifiInfo.security = static_cast<Exchange::INetworkManager::WIFISecurityMode>(wifiSecurityModeFromApFlags(wifiInfo.ssid, flags, wpaFlags, rsnFlags));
                 if(noise <= 0 && noise >= DEFAULT_NOISE)
-                    wifiInfo.noise = std::to_string(noise);
+                    wifiInfo.noise = noise;
                 else
-                    wifiInfo.noise = std::to_string(0);
+                    wifiInfo.noise = 0;
 
                 // NMLOG_DEBUG("SSID: %s", wifiInfo.m_ssid.c_str());
                 // NMLOG_DEBUG("bssid %s", wifiInfo.m_bssid.c_str());
@@ -436,10 +435,10 @@ namespace WPEFramework
         }
 
         // Function to convert percentage (0-100) to dBm string
-        const char* GnomeUtils::convertPercentageToSignalStrengtStr(int percentage) {
+        int GnomeUtils::convertPercentageToSignalStrength(int percentage) {
 
             if (percentage <= 0 || percentage > 100) {
-                return "";
+                return 0;
             }
 
            /*
@@ -455,9 +454,7 @@ namespace WPEFramework
             const int max_dBm = -30;
             const int min_dBm = -90;
             int dBm_value = max_dBm + ((min_dBm - max_dBm) * (100 - percentage)) / 100;
-            static char result[8]={0};
-            snprintf(result, sizeof(result), "%d", dBm_value);
-            return result;
+            return dBm_value;
         }
 
         bool GnomeUtils::getWifiConnectionPaths(DbusMgr& m_dbus, const char* devicePath, std::list<std::string>& paths)

--- a/plugin/gnome/gdbus/NetworkManagerGdbusUtils.h
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusUtils.h
@@ -86,7 +86,7 @@ namespace WPEFramework
                 static void addGvariantToBuilder(GVariant *variant, GVariantBuilder *builder, gboolean excludeRouteMetric);
 
                 static bool convertSsidInfoToJsonObject(Exchange::INetworkManager::WiFiSSIDInfo& wifiInfo, JsonObject& ssidObj);
-                static const char* convertPercentageToSignalStrengtStr(int percentage);
+                static int convertPercentageToSignalStrength(int percentage);
                 static uint8_t wifiSecurityModeFromApFlags(const std::string& ssid, guint32 flags, guint32 wpaFlags, guint32 rsnFlags);
                 static const char* getWifiIfname();
                 static const char* getEthIfname();

--- a/plugin/rdk/NetworkManagerRDKProxy.cpp
+++ b/plugin/rdk/NetworkManagerRDKProxy.cpp
@@ -266,8 +266,12 @@ namespace WPEFramework
                         {
                             JsonObject object = ssids[i].Object();
                             security = object["security"].Number();
-                            object["security"] = mapToNewSecurityMode(security);
-                            ssidsUpdated.Add(object);
+                            JsonObject newObject;
+                            newObject["ssid"] = object["ssid"];
+                            newObject["security"] = mapToNewSecurityMode(security);
+                            newObject["strength"] = object["signalStrength"];
+                            newObject["frequency"] = object["frequency"];
+                            ssidsUpdated.Add(newObject);
                         }
                         ::_instance->ReportAvailableSSIDs(ssidsUpdated);
                         break;
@@ -1173,24 +1177,23 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 ssidInfo.ssid             = string(connectedSsid.ssid);
                 ssidInfo.bssid            = string(connectedSsid.bssid);
                 ssidInfo.security         = (WIFISecurityMode)mapToNewSecurityMode(connectedSsid.securityMode);
-                ssidInfo.strength         = to_string((int)connectedSsid.signalStrength);
-                ssidInfo.rate             = to_string((int)connectedSsid.rate);
+                ssidInfo.strength         = (int)connectedSsid.signalStrength;
+                ssidInfo.rate             = (int)connectedSsid.rate;
 
                 if(((int) connectedSsid.noise >= 0) || ((int) connectedSsid.noise < DEFAULT_NOISE))
                 {
                     NMLOG_DEBUG ("Received Noise (%f) from wifi driver is not valid; so clamping it", connectedSsid.noise);
                     if (connectedSsid.noise >= 0) {
-                        ssidInfo.noise = std::to_string(0);
+                        ssidInfo.noise = 0;
                     }
                     else if (connectedSsid.noise < DEFAULT_NOISE) {
-                        ssidInfo.noise = std::to_string(DEFAULT_NOISE);
+                        ssidInfo.noise = DEFAULT_NOISE;
                     }
                 }
                 else
-                    ssidInfo.noise = std::to_string((int)connectedSsid.noise);
+                    ssidInfo.noise = (int)connectedSsid.noise;
 
-                std::string freqStr       = to_string((double)connectedSsid.frequency/1000);
-                ssidInfo.frequency        = freqStr.substr(0, 5);
+                ssidInfo.frequency        = ((double)connectedSsid.frequency/1000);
 
                 NMLOG_INFO ("GetConnectedSSID Success");
                 rc = Core::ERROR_NONE;

--- a/tests/l2Test/legacy/l2_test_LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/tests/l2Test/legacy/l2_test_LegacyPlugin_WiFiManagerAPIs.cpp
@@ -188,11 +188,11 @@ TEST_F(WiFiManagerTest, getConnectedSSID) {
     Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
     ssidInfo.ssid = "my-ssid";
     ssidInfo.bssid = "00:11:22:33:44:55";
-    ssidInfo.rate = "100";
-    ssidInfo.noise = "-50";
+    ssidInfo.rate = 100;
+    ssidInfo.noise = -50;
     ssidInfo.security = Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_WPA_PSK;
-    ssidInfo.strength = "50";
-    ssidInfo.frequency = "2.4";
+    ssidInfo.strength = 50;
+    ssidInfo.frequency = 2.4;
     EXPECT_CALL(*mockNetworkManager, GetConnectedSSID(::testing::_))
         .WillOnce(::testing::DoAll(
             ::testing::SetArgReferee<0>(ssidInfo),
@@ -221,11 +221,11 @@ TEST_F(WiFiManagerTest, getConnectedSSIDSAE) {
     Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
     ssidInfo.ssid = "my-ssid";
     ssidInfo.bssid = "00:11:22:33:44:55";
-    ssidInfo.rate = "100";
-    ssidInfo.noise = "-50";
+    ssidInfo.rate = 100;
+    ssidInfo.noise = -50;
     ssidInfo.security = Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_SAE;
-    ssidInfo.strength = "50";
-    ssidInfo.frequency = "2.4";
+    ssidInfo.strength = 50;
+    ssidInfo.frequency = 2.4;
     EXPECT_CALL(*mockNetworkManager, GetConnectedSSID(::testing::_))
         .WillOnce(::testing::DoAll(
             ::testing::SetArgReferee<0>(ssidInfo),
@@ -254,11 +254,11 @@ TEST_F(WiFiManagerTest, getConnectedSSIDEAP) {
     Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
     ssidInfo.ssid = "my-ssid";
     ssidInfo.bssid = "00:11:22:33:44:55";
-    ssidInfo.rate = "100";
-    ssidInfo.noise = "-50";
+    ssidInfo.rate = 100;
+    ssidInfo.noise = -50;
     ssidInfo.security = Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_EAP;
-    ssidInfo.strength = "50";
-    ssidInfo.frequency = "2.4";
+    ssidInfo.strength = 50;
+    ssidInfo.frequency = 2.4;
     EXPECT_CALL(*mockNetworkManager, GetConnectedSSID(::testing::_))
         .WillOnce(::testing::DoAll(
             ::testing::SetArgReferee<0>(ssidInfo),

--- a/tests/l2Test/libnm/l2_test_libnmproxyWifi.cpp
+++ b/tests/l2Test/libnm/l2_test_libnmproxyWifi.cpp
@@ -386,7 +386,7 @@ TEST_F(NetworkManagerWifiTest, GetConnectedSSID_ApNotConnected)
         .WillOnce(::testing::Return(NM_DEVICE_STATE_DISCONNECTED));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T(""), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"bssid\":\"\",\"security\":0,\"strength\":\"\",\"frequency\":\"\",\"rate\":\"\",\"noise\":\"\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"bssid\":\"\",\"security\":0,\"strength\":0,\"frequency\":0,\"rate\":0,\"noise\":0,\"success\":true}"));
 
     g_object_unref(deviceDummy);
     g_ptr_array_free(fakeDevices, TRUE);
@@ -467,7 +467,7 @@ TEST_F(NetworkManagerWifiTest, GetConnectedSSID_Connected_psk)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T(""), response));
     
     // Update expected response to match the mock data
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestWiFiNetwork\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":2,\"strength\":\"-39\",\"frequency\":\"2.462\",\"rate\":\"54000\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestWiFiNetwork\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":2,\"strength\":-39,\"frequency\":2.462,\"rate\":54000,\"noise\":0,\"success\":true}"));
 
     // Free the GBytes object
     g_bytes_unref(fake_ssid);
@@ -528,7 +528,7 @@ TEST_F(NetworkManagerWifiTest, GetConnectedSSID_Connected_EAP)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T(""), response));
     
     // Update expected response to match the mock data
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestWiFiNetwork\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":3,\"strength\":\"-39\",\"frequency\":\"2.462\",\"rate\":\"54000\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestWiFiNetwork\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":3,\"strength\":-39,\"frequency\":2.462,\"rate\":54000,\"noise\":0,\"success\":true}"));
 
     // Free the GBytes object
     g_bytes_unref(fake_ssid);
@@ -589,7 +589,7 @@ TEST_F(NetworkManagerWifiTest, GetConnectedSSID_Connected_ssidNull)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T(""), response));
     
     // Update expected response to match the mock data
-    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":1,\"strength\":\"-78\",\"frequency\":\"2.462\",\"rate\":\"54000\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"bssid\":\"AA:BB:CC:DD:EE:FF\",\"security\":1,\"strength\":-78,\"frequency\":2.462,\"rate\":54000,\"noise\":0,\"success\":true}"));
 
     // Free the GBytes object
     g_bytes_unref(fake_ssid);

--- a/tests/l2Test/rdk/l2_test_rdkproxy.cpp
+++ b/tests/l2Test/rdk/l2_test_rdkproxy.cpp
@@ -921,7 +921,7 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success)
         ));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":-30,\"frequency\":2.412,\"rate\":0,\"noise\":0,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_9999)
@@ -946,7 +946,7 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_9999)
         ));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":-30,\"frequency\":2.412,\"rate\":0,\"noise\":0,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_100)
@@ -971,7 +971,7 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_100)
         ));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"-96\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":-30,\"frequency\":2.412,\"rate\":0,\"noise\":-96,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_50)
@@ -996,7 +996,7 @@ TEST_F(NetworkManagerTest, GetConnectedSSID_Success_noise_50)
         ));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetConnectedSSID"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":\"-30\",\"frequency\":\"2.412\",\"rate\":\"0\",\"noise\":\"-50\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"TestNetwork\",\"bssid\":\"AB:CD:EF:GH:IJ:KL\",\"security\":1,\"strength\":-30,\"frequency\":2.412,\"rate\":0,\"noise\":-50,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetConnectedSSID_Failed)
@@ -1331,7 +1331,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityDisconnected2)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"quality\":\"Disconnected\",\"snr\":\"0\",\"strength\":\"0\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"\",\"quality\":\"Disconnected\",\"snr\":0,\"strength\":0,\"noise\":0,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnected)
@@ -1369,7 +1369,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnected)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":\"66\",\"strength\":\"-30\",\"noise\":\"-96\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":66,\"strength\":-30,\"noise\":-96,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedGood)
@@ -1407,7 +1407,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedGood)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Weak\",\"snr\":\"6\",\"strength\":\"-90\",\"noise\":\"-96\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Weak\",\"snr\":6,\"strength\":-90,\"noise\":-96,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedLowBad)
@@ -1445,7 +1445,7 @@ TEST_F(NetworkManagerTest, GetWiFiSignalQualityConnectedLowBad)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("GetWiFiSignalQuality"), _T("{}"), response));
-    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":\"120\",\"strength\":\"-120\",\"noise\":\"0\",\"success\":true}"));
+    EXPECT_EQ(response, _T("{\"ssid\":\"dummySSID\",\"quality\":\"Excellent\",\"snr\":120,\"strength\":-120,\"noise\":0,\"success\":true}"));
 }
 
 TEST_F(NetworkManagerTest, Trace_Success_ipv4)

--- a/tests/mocks/INetworkManagerMock.h
+++ b/tests/mocks/INetworkManagerMock.h
@@ -47,7 +47,7 @@ public:
     MOCK_METHOD(uint32_t, StartWPS, (const WiFiWPS& method, const string& pin), (override));
     MOCK_METHOD(uint32_t, StopWPS, (), (override));
     MOCK_METHOD(uint32_t, GetWifiState, (WPEFramework::Exchange::INetworkManager::WiFiState& state), (override));
-    MOCK_METHOD(uint32_t, GetWiFiSignalQuality, (string& ssid, string& strength, string& noise, string& snr, WPEFramework::Exchange::INetworkManager::WiFiSignalQuality& quality), (override));
+    MOCK_METHOD(uint32_t, GetWiFiSignalQuality, (string& ssid, int& strength, int& noise, int& snr, WPEFramework::Exchange::INetworkManager::WiFiSignalQuality& quality), (override));
     MOCK_METHOD(uint32_t, GetSupportedSecurityModes, (ISecurityModeIterator*& modes), (const));
     MOCK_METHOD(uint32_t, SetLogLevel, (const Logging& level), (override));
     MOCK_METHOD(uint32_t, SetHostname, (const string& hostname), (override));

--- a/tools/plugincli/NetworkManagerGdbusTest.cpp
+++ b/tools/plugincli/NetworkManagerGdbusTest.cpp
@@ -63,7 +63,7 @@ namespace WPEFramework
         {
             NMLOG_INFO("calling 'ReportWiFiStateChange' cb");
         }
-        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             NMLOG_INFO("calling 'ReportWiFiSignalQualityChange' cb");
         }
@@ -272,10 +272,11 @@ int main()
             }
 
             case 10: {
-                std::string ssid, signalStrength;
+                std::string ssid;
+                int signalStrength;
                 Exchange::INetworkManager::WiFiSignalQuality quality;
                 if (nmClient->getWiFiSignalQuality(ssid, signalStrength, quality)) {
-                    NMLOG_INFO("SSID: %s, Signal Strength: %s, Quality: %d", ssid.c_str(), signalStrength.c_str(), quality);
+                    NMLOG_INFO("SSID: %s, Signal Strength: %d, Quality: %d", ssid.c_str(), signalStrength, quality);
                 } else {
                     NMLOG_ERROR("Failed to get WiFi signal strength");
                 }

--- a/tools/plugincli/NetworkManagerLibnmTest.cpp
+++ b/tools/plugincli/NetworkManagerLibnmTest.cpp
@@ -62,7 +62,7 @@ namespace WPEFramework
         {
             NMLOG_INFO("calling 'ReportWiFiStateChange' cb");
         }
-        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const string strength, const string noise, const string snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
+        void NetworkManagerImplementation::ReportWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality)
         {
             NMLOG_INFO("calling 'ReportWiFiSignalQualityChange' cb");
         }


### PR DESCRIPTION
Reason for change: Updated the onAvailableSSID to return strength and frequency as numbers so that the UI will do the sorting.
Test Procedure: Check the onAvailableSSID returns strength and frequency as numbers
Priority:P1
Risks: Medium