### PR TITLE
nm-cli unmanage wl0.2

### DIFF
--- a/plugin/gnome/scripts/nm_interface_handler.sh
+++ b/plugin/gnome/scripts/nm_interface_handler.sh
@@ -82,8 +82,8 @@ fi
 P2P_INTERFACES="wl0.2 p2p-dev-wl0.2"
 for P2P_IF in $P2P_INTERFACES
 do
-echo "`/bin/timestamp` :$0: setting $P2P_IF unmanaged for Miracast" >> /opt/logs/NMMonitor.log
-nmcli device disconnect "$P2P_IF" 2>/dev/null
-nmcli dev set "$P2P_IF" managed no 2>/dev/null
+    echo "`/bin/timestamp` :$0: setting $P2P_IF unmanaged for Miracast" >> /opt/logs/NMMonitor.log
+    nmcli device disconnect "$P2P_IF" 2>/dev/null
+    nmcli dev set "$P2P_IF" managed no 2>/dev/null
 done
 exit 0

--- a/plugin/gnome/scripts/nm_interface_handler.sh
+++ b/plugin/gnome/scripts/nm_interface_handler.sh
@@ -77,3 +77,13 @@ if [ -f "$NM_WIFI_MARKER" ]; then
     nmcli device disconnect "$WIFI_INTERFACE"
     nmcli dev set "$WIFI_INTERFACE" managed no
 fi
+
+# Disable Broadcom Miracast P2P interfaces
+P2P_INTERFACES="wl0.2 p2p-dev-wl0.2"
+for P2P_IF in $P2P_INTERFACES
+do
+echo "`/bin/timestamp` :$0: setting $P2P_IF unmanaged for Miracast" >> /opt/logs/NMMonitor.log
+nmcli device disconnect "$P2P_IF" 2>/dev/null
+nmcli dev set "$P2P_IF" managed no 2>/dev/null
+done
+exit 0


### PR DESCRIPTION
For disabling broadcom Miracast P2P interfaces, doing wl0.2 unmanaged in nmcli