### PR TITLE
RDKEMW-15311 : Use key-mgmt as SAE for WPA2-WPA3 Transition mode SSIDs

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -736,6 +736,10 @@ namespace WPEFramework
                         }
                         return false;
                     }
+                    
+                    sSecurity = (NMSettingWirelessSecurity *) nm_setting_wireless_security_new();
+                    nm_connection_add_setting(m_connection, NM_SETTING(sSecurity));
+                    g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"wpa-eap", NULL);
                     break;
                 }
                 case Exchange::INetworkManager::WIFI_SECURITY_NONE:

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -736,7 +736,6 @@ namespace WPEFramework
                         }
                         return false;
                     }
-                    
                     sSecurity = (NMSettingWirelessSecurity *) nm_setting_wireless_security_new();
                     nm_connection_add_setting(m_connection, NM_SETTING(sSecurity));
                     g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"wpa-eap", NULL);

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -736,6 +736,7 @@ namespace WPEFramework
                         }
                         return false;
                     }
+                    
                     sSecurity = (NMSettingWirelessSecurity *) nm_setting_wireless_security_new();
                     nm_connection_add_setting(m_connection, NM_SETTING(sSecurity));
                     g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"wpa-eap", NULL);

--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -662,16 +662,6 @@ namespace WPEFramework
 
                     sSecurity = (NMSettingWirelessSecurity *) nm_setting_wireless_security_new();
                     nm_connection_add_setting(m_connection, NM_SETTING(sSecurity));
-                    if(Exchange::INetworkManager::WIFISecurityMode::WIFI_SECURITY_SAE == ssidinfo.security)
-                    {
-                        NMLOG_INFO("key-mgmt: %s", "sae");
-                        g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"sae", NULL);
-                    }
-                    else
-                    {
-                        NMLOG_INFO("key-mgmt: %s", "wpa-psk");
-                        g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"wpa-psk", NULL);
-                    }
 
                     /* if ap is not a wps network */
                     if(!iswpsAP)
@@ -746,10 +736,6 @@ namespace WPEFramework
                         }
                         return false;
                     }
-
-                    sSecurity = (NMSettingWirelessSecurity *) nm_setting_wireless_security_new();
-                    nm_connection_add_setting(m_connection, NM_SETTING(sSecurity));
-                    g_object_set(G_OBJECT(sSecurity), NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,"wpa-eap", NULL);
                     break;
                 }
                 case Exchange::INetworkManager::WIFI_SECURITY_NONE:


### PR DESCRIPTION
Reason for Change: Remove the explicit set of security mode
Test Procedure: Check wifi connect with all security mode
Priority: P1
Risks: Medium
Signed-off-by: jincysaramma_sam@comcast.com