### PR TITLE
RDKEMW-10793: [NetworkManager] Reduce repetitive logging

### DIFF
--- a/legacy/LegacyNetworkAPIs.cpp
+++ b/legacy/LegacyNetworkAPIs.cpp
@@ -31,6 +31,8 @@ using namespace WPEFramework::Plugin;
 
 #define LOG_INPARAM() { string json; parameters.ToString(json); NMLOG_INFO("params=%s", json.c_str() ); }
 #define LOG_OUTPARAM() { string json; response.ToString(json); NMLOG_INFO("response=%s", json.c_str() ); }
+#define DEBUGLOG_INPARAM() { string json; parameters.ToString(json); NMLOG_DEBUG("params=%s", json.c_str() ); }
+#define DEBUGLOG_OUTPARAM() { string json; response.ToString(json); NMLOG_DEBUG("response=%s", json.c_str() ); }
 
 #define returnJson(rc) \
     { \
@@ -516,7 +518,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
             uint32_t rc = Core::ERROR_GENERAL;
             JsonObject tmpResponse;
 
-            LOG_INPARAM();
+            DEBUGLOG_INPARAM();
             rc = internalGetIPSettings(parameters, tmpResponse);
 
             if (tmpResponse.HasLabel("ipaddr") && (!tmpResponse["ipaddr"].String().empty()))
@@ -526,17 +528,26 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN+1] = {
                 NMLOG_INFO("IP Address not assigned to the given interface yet");
                 rc = Core::ERROR_GENERAL;
             }
-            returnJson(rc);
+            if (Core::ERROR_NONE == rc)
+                response["success"] = true;
+            else
+                response["success"] = false;
+            DEBUGLOG_OUTPARAM();
+            return Core::ERROR_NONE;
         }
 
         uint32_t Network::getIPSettings2 (const JsonObject& parameters, JsonObject& response)
         {
-            LOG_INPARAM();
+            DEBUGLOG_INPARAM();
             uint32_t rc = Core::ERROR_GENERAL;
 
             rc = internalGetIPSettings(parameters, response);
-
-            returnJson(rc);
+            if (Core::ERROR_NONE == rc)
+                response["success"] = true;
+            else
+                response["success"] = false;
+            DEBUGLOG_OUTPARAM();
+            return Core::ERROR_NONE;
         }
 
         uint32_t Network::isConnectedToInternet(const JsonObject& parameters, JsonObject& response)

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -716,7 +716,7 @@ namespace WPEFramework
                             }
                             result.ipaddress = nm_ip_address_get_address(ipAddr);
                             result.prefix = nm_ip_address_get_prefix(ipAddr);
-                            NMLOG_INFO("IPv4 addr: %s/%d", result.ipaddress.c_str(), result.prefix);
+                            NMLOG_DEBUG("IPv4 addr: %s/%d", result.ipaddress.c_str(), result.prefix);
                         }
                     }
                     gateway = nm_ip_config_get_gateway(ip4_config);
@@ -781,14 +781,14 @@ namespace WPEFramework
                             if (ipStr.compare(0, 5, "fe80:") == 0 || ipStr.compare(0, 6, "fe80::") == 0)
                             {
                                 result.ula = ipStr;
-                                NMLOG_INFO("link-local ip: %s", result.ula.c_str());
+                                NMLOG_DEBUG("link-local ip: %s", result.ula.c_str());
                             }
                             else
                             {
                                 result.prefix = nm_ip_address_get_prefix(ipAddr);
                                 if(result.ipaddress.empty()) // SLAAC mutiple ip not added
                                     result.ipaddress = ipStr;
-                                NMLOG_INFO("global ip %s/%d", ipStr.c_str(), result.prefix);
+                                NMLOG_DEBUG("global ip %s/%d", ipStr.c_str(), result.prefix);
                             }
                         }
                     }


### PR DESCRIPTION
Reason for Change: Changed the repetitive getIPSettings log from INFO to debug
Test Procedure: Check whether the logs are getting printed in the wpeframework.log
Priority: P1
Risks: Medium