### PR TITLE
RDKEMW-20470 : Log signal quality every 5s

### DIFF
--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -45,7 +45,7 @@ using namespace std;
 #define DEFAULT_NOISE                              -96
 #define MAX_SNR_VALUE                              180
 
-#define DEFAULT_WIFI_SIGNAL_TEST_INTERVAL_SEC      60
+#define DEFAULT_WIFI_SIGNAL_TEST_INTERVAL_SEC      5
 #define NM_PROCESS_MONITOR_INTERVAL_SEC            60
 #define NM_WIFI_SNR_THRESHOLD_EXCELLENT            40
 #define NM_WIFI_SNR_THRESHOLD_GOOD                 25


### PR DESCRIPTION
Reason for change: Log signal quality every 5s
Test procedure: Check in wpeframework logs for signal quality 
Risks: low
Priority: P1

Signed-off-by: jincysaramma_sam@comcast.com