### PR TITLE
RDKEMW-20973: reconnect failure on deepsleep wakeup with NSM OFF

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -1151,7 +1151,8 @@ namespace WPEFramework
 
                 GetWiFiSignalQuality(ssid, strength, noise, snr, newSignalQuality);
 
-                m_lastConnectedSSID = ssid; // last connected ssid used in wifiConnect
+                if (!ssid.empty())
+                    m_lastConnectedSSID = ssid; // last connected ssid used in wifiConnect
 
                 if (oldSignalQuality != newSignalQuality) {
                     oldSignalQuality = newSignalQuality;


### PR DESCRIPTION
Reason for change: fix deepsleep reconnect failure due to "wpa_cli status" returning empty BSSID which cleared last SSID 
Test procedure: WiFi should reconnect on DeepSleep wakeup Risks: low
Priority: P1