### PR TITLE
RDKEMW-21453: LegacyNetworkAPIs logs are not printed under wpeframework logs

### DIFF
--- a/legacy/LegacyNetworkAPIs.cpp
+++ b/legacy/LegacyNetworkAPIs.cpp
@@ -96,6 +96,7 @@ namespace WPEFramework
 
         const string Network::Initialize(PluginHost::IShell*  service )
         {
+            NetworkManagerLogger::Init();
             m_service = service;
             m_service->AddRef();
             string message{};

--- a/legacy/LegacyWiFiManagerAPIs.cpp
+++ b/legacy/LegacyWiFiManagerAPIs.cpp
@@ -128,6 +128,7 @@ namespace WPEFramework
 
         const string WiFiManager::Initialize(PluginHost::IShell*  service )
         {
+            NetworkManagerLogger::Init();
             m_service = service;
             string message{};
 

--- a/plugin/NetworkManager.cpp
+++ b/plugin/NetworkManager.cpp
@@ -84,12 +84,6 @@ namespace WPEFramework
             // Still running inside the main WPEFramework process - the child process will have now been spawned and registered if necessary
             if (_networkManager != nullptr)
             {
-
-                // Set the plugin log level
-                Exchange::INetworkManager::Logging _loglevel;
-                _networkManager->GetLogLevel(_loglevel);
-                NetworkManagerLogger::SetLevel(static_cast <NetworkManagerLogger::LogLevel>(_loglevel));
-
                 // Register Notifications
                 SYSLOG(Logging::Startup, (_T("Registering Notification to NetworkManager")));
                 _networkManager->Register(&_notification);
@@ -103,6 +97,11 @@ namespace WPEFramework
                 {
                     SYSLOG(Logging::Startup, (_T("Configuring successful")));
                 }
+
+                // Set the plugin log level
+                Exchange::INetworkManager::Logging _loglevel;
+                _networkManager->GetLogLevel(_loglevel);
+                NetworkManagerLogger::SetLevel(static_cast <NetworkManagerLogger::LogLevel>(_loglevel));
                 // Register all custom JSON-RPC methods
                 SYSLOG(Logging::Startup, (_T("Registering JSONRPC Methods")));
                 RegisterAllMethods();

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -384,11 +384,6 @@ namespace WPEFramework
                     NMLOG_INFO("NM_PUBLIC_IPV4 = %s", ipaddress.c_str());
                     logTelemetry("NM_PUBLIC_IPV4", ipaddress);
                 }
-                else
-                {
-                    NMLOG_INFO("NM_PUBLIC_IPV6 = %s", ipaddress.c_str());
-                    logTelemetry("NM_PUBLIC_IPV6", ipaddress);
-                }
 #endif
                 return Core::ERROR_NONE;
             }

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -65,7 +65,7 @@ namespace WPEFramework
 
             /* Initialize Network Manager */
             NetworkManagerLogger::Init();
-            SYSLOG(Logging::Startup, (_T("NWMgrPlugin Out-Of-Process Instantiation; SHA: " _T(EXPAND_AND_QUOTE(PLUGIN_BUILD_REFERENCE)))));
+            SYSLOG(::WPEFramework::Logging::Startup, (_T("NWMgrPlugin Out-Of-Process Instantiation; SHA: " _T(EXPAND_AND_QUOTE(PLUGIN_BUILD_REFERENCE)))));
             m_processMonThread = std::thread(&NetworkManagerImplementation::processMonitor, this, NM_PROCESS_MONITOR_INTERVAL_SEC);
             #if USE_TELEMETRY
                 // Initialize Telemetry T2 for NwMgrPlugin
@@ -142,12 +142,12 @@ namespace WPEFramework
             Configuration config;
             if(configLine.empty())
             {
-                SYSLOG(Logging::Startup, (_T("config line is empty")));
+                SYSLOG(::WPEFramework::Logging::Startup, (_T("config line is empty")));
                 return Core::ERROR_GENERAL;
             }
             else
             {
-                SYSLOG(Logging::Startup, (_T("Loading incoming configuration")));
+                SYSLOG(::WPEFramework::Logging::Startup, (_T("Loading incoming configuration")));
                 config.FromString(configLine);
             }
 

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -65,7 +65,7 @@ namespace WPEFramework
 
             /* Initialize Network Manager */
             NetworkManagerLogger::Init();
-            NMLOG_INFO((_T("NWMgrPlugin Out-Of-Process Instantiation; SHA: " _T(EXPAND_AND_QUOTE(PLUGIN_BUILD_REFERENCE)))));
+            SYSLOG(Logging::Startup, (_T("NWMgrPlugin Out-Of-Process Instantiation; SHA: " _T(EXPAND_AND_QUOTE(PLUGIN_BUILD_REFERENCE)))));
             m_processMonThread = std::thread(&NetworkManagerImplementation::processMonitor, this, NM_PROCESS_MONITOR_INTERVAL_SEC);
             #if USE_TELEMETRY
                 // Initialize Telemetry T2 for NwMgrPlugin
@@ -142,12 +142,12 @@ namespace WPEFramework
             Configuration config;
             if(configLine.empty())
             {
-                NMLOG_FATAL("config line : is empty !");
+                SYSLOG(Logging::Startup, (_T("config line is empty")));
                 return Core::ERROR_GENERAL;
             }
             else
             {
-                NMLOG_INFO("Loading the incoming configuration : %s", configLine.c_str());
+                SYSLOG(Logging::Startup, (_T("Loading incoming configuration")));
                 config.FromString(configLine);
             }
 
@@ -383,6 +383,11 @@ namespace WPEFramework
                 {
                     NMLOG_INFO("NM_PUBLIC_IPV4 = %s", ipaddress.c_str());
                     logTelemetry("NM_PUBLIC_IPV4", ipaddress);
+                }
+                else
+                {
+                    NMLOG_INFO("NM_PUBLIC_IPV6 = %s", ipaddress.c_str());
+                    logTelemetry("NM_PUBLIC_IPV6", ipaddress);
                 }
 #endif
                 return Core::ERROR_NONE;


### PR DESCRIPTION
Reason for Change: Fixed the legacy prints and SHA not printing issue
Test Procedure: Check whether legacy prints are getting printed along with the SHA of the tag.
Priority: P1