### PR TITLE
RDKEMW-22632: Order service start after PowerManager

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -160,6 +160,8 @@ if(ENABLE_GNOME_NETWORKMANAGER)
             DESTINATION  ${CMAKE_INSTALL_PREFIX}/../lib/rdk)
     install(FILES gnome/systemd/gnome-networkmanager-migration.conf
             DESTINATION ${CMAKE_INSTALL_PREFIX}/../lib/systemd/system/wpeframework-networkmanager.service.d)
+    install(FILES gnome/systemd/nm-powermanager.conf
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/../lib/systemd/system/wpeframework-networkmanager.service.d)
 endif(ENABLE_GNOME_NETWORKMANAGER)
 
 #Generate Plugin configuration file

--- a/plugin/NetworkManagerPowerClient.cpp
+++ b/plugin/NetworkManagerPowerClient.cpp
@@ -34,12 +34,13 @@ NetworkManagerPowerClient::NetworkManagerPowerClient(INetworkPowerCallback& call
     , mPreChangeNotification(*this)
     , mChangedNotification(*this)
 {
-    NMLOG_INFO("connecting to PowerManager");
+    NMLOG_INFO("NetworkManagerPowerClient ctor");
     if (auto r = Open(RPC::CommunicationTimeOut, Connector(), "org.rdk.PowerManager"); r == Core::ERROR_NONE) {
         // Connected; Operational() will be called by the framework when the proxy is ready
     } else {
         NMLOG_ERROR("failed to open link to PowerManager (error %u)", r);
     }
+    NMLOG_INFO("NetworkManagerPowerClient ctor ends");
 }
 
 NetworkManagerPowerClient::~NetworkManagerPowerClient()

--- a/plugin/gnome/systemd/nm-powermanager.conf
+++ b/plugin/gnome/systemd/nm-powermanager.conf
@@ -1,0 +1,3 @@
+[Unit]
+# Ensure NetworkManager starts after PowerManager
+After=wpeframework-powermanager.service

--- a/plugin/gnome/systemd/nm-powermanager.conf
+++ b/plugin/gnome/systemd/nm-powermanager.conf
@@ -1,3 +1,4 @@
 [Unit]
 # Ensure NetworkManager starts after PowerManager
+Wants=wpeframework-powermanager.service
 After=wpeframework-powermanager.service


### PR DESCRIPTION
Reason for change: Ensure PowerManager service is started before NetworkManager
Test procedure: Reboot, then inspect the order units actually started
Risks: low
Priority: P1