### PR TITLE
RDKEMW-22842: onWiFiStateChange Event to Include Wi-Fi Profile Info

### DIFF
--- a/definition/NetworkManager.json
+++ b/definition/NetworkManager.json
@@ -1556,6 +1556,11 @@
                         "summary": "WiFi status",
                         "type": "string",
                         "example": "WIFI_STATE_CONNECTED"
+                    },
+                    "ssid": {
+                        "summary": "The SSID associated with the Wi-Fi profile causing the state transition. For a disconnected state, this is the SSID that was previously connected, when available; otherwise an empty string",
+                        "type": "string",
+                        "example": "myHomeSSID"
                     }
                 },
                 "required": [

--- a/docs/NetworkManagerPlugin.md
+++ b/docs/NetworkManagerPlugin.md
@@ -1966,6 +1966,7 @@ Triggered when WIFI connection state get changed. The possible states are define
 | params | object |  |
 | params.state | integer | WiFi State |
 | params.status | string | WiFi status |
+| params?.ssid | string | <sup>*(optional)*</sup> The SSID associated with the Wi-Fi profile causing the state transition. For a disconnected state, this is the SSID that was previously connected, when available; otherwise an empty string |
 
 ### Example
 
@@ -1975,7 +1976,8 @@ Triggered when WIFI connection state get changed. The possible states are define
   "method": "client.events.1.onWiFiStateChange",
   "params": {
     "state": 5,
-    "status": "WIFI_STATE_CONNECTED"
+    "status": "WIFI_STATE_CONNECTED",
+    "ssid": "myHomeSSID"
   }
 }
 ```

--- a/interface/INetworkManager.h
+++ b/interface/INetworkManager.h
@@ -286,7 +286,7 @@ namespace WPEFramework
 
                 // WiFi Notifications that other processes can subscribe to
                 virtual void onAvailableSSIDs(const string jsonOfScanResults /* @in */){};
-                virtual void onWiFiStateChange(const WiFiState state /* @in */){};
+                virtual void onWiFiStateChange(const WiFiState state /* @in */, const string ssid /* @in */){};
                 virtual void onWiFiSignalQualityChange(const string ssid /* @in */, const int strength /* @in */, const int noise /* @in */, const int snr /* @in */, const WiFiSignalQuality quality /* @in */){};
             };
 

--- a/plugin/NetworkManager.h
+++ b/plugin/NetworkManager.h
@@ -89,9 +89,9 @@ namespace WPEFramework
                     _parent.onAvailableSSIDs(jsonOfScanResults);
                 }
 
-                void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state) override
+                void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state, const string ssid) override
                 {
-                    _parent.onWiFiStateChange(state);
+                    _parent.onWiFiStateChange(state, ssid);
                 }
 
                 void onWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality) override
@@ -262,7 +262,7 @@ namespace WPEFramework
             void onIPAddressChange(const string interface, const string ipversion, const string ipaddress, const Exchange::INetworkManager::IPStatus status);
             void onInternetStatusChange(const Exchange::INetworkManager::InternetStatus prevState, const Exchange::INetworkManager::InternetStatus currState, const string interface);
             void onAvailableSSIDs(const string jsonOfScanResults);
-            void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state);
+            void onWiFiStateChange(const Exchange::INetworkManager::WiFiState state, const string ssid);
             void onWiFiSignalQualityChange(const string ssid, const int strength, const int noise, const int snr, const Exchange::INetworkManager::WiFiSignalQuality quality);
 
         private:

--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -818,7 +818,7 @@ namespace WPEFramework
                     NMLOG_INFO("Publishing onWiFiStateChange Event");
                     const auto& eventData = std::get<WiFiStateChangeData>(data);
                     for (const auto callback : callbacks) {
-                        callback->onWiFiStateChange(eventData.state);
+                        callback->onWiFiStateChange(eventData.state, eventData.ssid);
                         callback->Release();
                     }
                 }
@@ -1354,10 +1354,15 @@ namespace WPEFramework
         void NetworkManagerImplementation::ReportWiFiStateChange(const Exchange::INetworkManager::WiFiState state)
         {
             LOG_ENTRY_FUNCTION();
+            static std::string lastKnownSSID;
+
             /* start signal strength monitor when wifi connected */
             if(INetworkManager::WiFiState::WIFI_STATE_CONNECTED == state)
             {
                 m_wlanConnected.store(true);
+                Exchange::INetworkManager::WiFiSSIDInfo ssidInfo{};
+                if ((GetConnectedSSID(ssidInfo) == Core::ERROR_NONE) && !ssidInfo.ssid.empty())
+                    lastKnownSSID = ssidInfo.ssid;
                 startWiFiSignalQualityMonitor(DEFAULT_WIFI_SIGNAL_TEST_INTERVAL_SEC);
             }
             else
@@ -1366,14 +1371,14 @@ namespace WPEFramework
                 m_wlanConnected.store(false); /* Any other state is considered as WiFi not connected. */
             }
 
-            NMLOG_INFO("Posting onWiFiStateChange (%d)", state);
+            NMLOG_INFO("Posting onWiFiStateChange (%d) ssid: %s", state, lastKnownSSID.c_str());
 #if USE_TELEMETRY
             string stateStr = Core::EnumerateType<Exchange::INetworkManager::WiFiState>(state).Data();
             NMLOG_INFO("NM_WIFI_STATUS = %s", stateStr.c_str());
             logTelemetry("NM_WIFI_STATUS", stateStr);
 #endif
             {
-                WiFiStateChangeData eventData{state};
+                WiFiStateChangeData eventData{state, lastKnownSSID};
                 enqueueEvent(NM_ON_WIFISTATE_CHANGE, std::move(eventData));
             }
         }

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -251,6 +251,7 @@ namespace WPEFramework
 
             struct WiFiStateChangeData {
                 Exchange::INetworkManager::WiFiState state;
+                string ssid;
             };
 
             struct WiFiSignalQualityChangeData {

--- a/plugin/NetworkManagerJsonRpc.cpp
+++ b/plugin/NetworkManagerJsonRpc.cpp
@@ -1105,12 +1105,13 @@ namespace WPEFramework
             Notify(_T("onAvailableSSIDs"), parameters);
         }
 
-        void NetworkManager::onWiFiStateChange(const Exchange::INetworkManager::WiFiState state)
+        void NetworkManager::onWiFiStateChange(const Exchange::INetworkManager::WiFiState state, const string ssid)
         {
             JsonObject parameters;
             Core::JSON::EnumType<Exchange::INetworkManager::WiFiState> iState{state};
             parameters["state"] = JsonValue(state);
             parameters["status"] = iState.Data();
+            parameters["ssid"] = ssid;
 
             LOG_INPARAM();
             Notify(_T("onWiFiStateChange"), parameters);


### PR DESCRIPTION
Reason for change: onWiFiStateChange event currently reports only the Wi-Fi connection state. 
Enhance onWiFiStateChange event payload to include the connected or affected Wi-Fi SSID. 
Priority: P1
Test Procedure: Refer ticket RDKEMW-23159
Risks: Low

Signed-off-by: Mehavarshni_Palaniswamy@comcast.com