### PR TITLE
RDKEMW-23361 : Failed to Connect to Hidden SSID

### DIFF
--- a/plugin/gnome/NetworkManagerGnomeWIFI.cpp
+++ b/plugin/gnome/NetworkManagerGnomeWIFI.cpp
@@ -1186,6 +1186,7 @@ m_cancellable(nullptr){
                 /* ssid not found in scan list so add to known ssid it will do a scanning and connect */
                 if(ssidInfo.persist)
                 {
+                    deleteClientConnection();
                     if(addToKnownSSIDs(ssidInfo))
                     {
                         NMLOG_DEBUG("Adding to known ssid '%s' ", ssidInfo.ssid.c_str());


### PR DESCRIPTION
Reason for change: wifi connect call with invalid/hidden SSID results in IPC timeout
Test Procedure: Issue wifi connect does not timeout even if SSID is invalid/hidden
Risks: Medium

Signed-off-by: jincysaramma_sam@cable.comcast.com