### PR TITLE
RDKEMW-21048: Mutex to access m_lastConnectedSSID in NMPlugin

### DIFF
--- a/plugin/NetworkManagerImplementation.cpp
+++ b/plugin/NetworkManagerImplementation.cpp
@@ -1328,7 +1328,7 @@ namespace WPEFramework
                 GetWiFiSignalQuality(ssid, strength, noise, snr, newSignalQuality);
 
                 if (!ssid.empty())
-                    m_lastConnectedSSID = ssid; // last connected ssid used in wifiConnect
+                    setLastConnectedSSID(ssid); // last connected ssid used in wifiConnect
 
                 if (oldSignalQuality != newSignalQuality) {
                     oldSignalQuality = newSignalQuality;
@@ -1457,11 +1457,12 @@ namespace WPEFramework
             {
                 if (m_wlanDisconnectedForSleep.load())
                 {
-                    if (!m_lastConnectedSSID.empty())
+                    const std::string lastConnectedSSID = getLastConnectedSSID();
+                    if (!lastConnectedSSID.empty())
                     {
                         NMLOG_INFO("OnPowerModePreChange: waking from DeepSleep — reconnecting to '%s'",
-                               m_lastConnectedSSID.c_str());
-                        uint32_t rcWifiUp = ConnectToKnownSSID(m_lastConnectedSSID);
+                               lastConnectedSSID.c_str());
+                        uint32_t rcWifiUp = ConnectToKnownSSID(lastConnectedSSID);
                         if (rcWifiUp == Core::ERROR_NONE)
                         {
                             m_wlanDisconnectedForSleep.store(false);

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -481,7 +481,7 @@ namespace WPEFramework
             private:
                 string m_defaultInterface;
                 mutable std::mutex m_defaultInterfaceMutex;
-		mutable std::mutex m_lastConnectedSSIDMutex;
+                mutable std::mutex m_lastConnectedSSIDMutex;
                 std::map<std::pair<std::string, std::string>, IpFamilyCache> m_ipCacheMap;
                 mutable std::mutex m_ipCacheMutex;
         };

--- a/plugin/NetworkManagerImplementation.h
+++ b/plugin/NetworkManagerImplementation.h
@@ -466,9 +466,22 @@ namespace WPEFramework
                     m_defaultInterface = iface;
                 }
 
+                void setLastConnectedSSID(const std::string& ssid)
+                {
+                    std::lock_guard<std::mutex> lock(m_lastConnectedSSIDMutex);
+                    m_lastConnectedSSID = ssid;
+                }
+
+                std::string getLastConnectedSSID() const
+                {
+                    std::lock_guard<std::mutex> lock(m_lastConnectedSSIDMutex);
+                    return m_lastConnectedSSID;
+                }
+
             private:
                 string m_defaultInterface;
                 mutable std::mutex m_defaultInterfaceMutex;
+		mutable std::mutex m_lastConnectedSSIDMutex;
                 std::map<std::pair<std::string, std::string>, IpFamilyCache> m_ipCacheMap;
                 mutable std::mutex m_ipCacheMutex;
         };

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -629,8 +629,9 @@ namespace WPEFramework
                 if(enabled && interface == nmUtils::wlanIface() && _instance != NULL)
                 {
                     sleep(1); // wait for 1 sec to change the device state
-                    NMLOG_INFO("Activating connection '%s' ...", _instance->m_lastConnectedSSID.c_str());
-                    wifi->activateKnownConnection(nmUtils::wlanIface(), _instance->m_lastConnectedSSID);
+                    const string lastConnectedSSID = _instance->getLastConnectedSSID();
+                    NMLOG_INFO("Activating connection '%s' ...", lastConnectedSSID.c_str());
+                    wifi->activateKnownConnection(nmUtils::wlanIface(), lastConnectedSSID);
                 }
             }
 
@@ -890,7 +891,7 @@ namespace WPEFramework
             if(ssid.ssid.empty())
             {
                 NMLOG_WARNING("ssid is empty activating last connected ssid !");
-                if(_instance != NULL && wifi->activateKnownConnection(nmUtils::wlanIface(), _instance->m_lastConnectedSSID))
+	        if(_instance != NULL && wifi->activateKnownConnection(nmUtils::wlanIface(), _instance->getLastConnectedSSID()))
                 {
                     rc = Core::ERROR_NONE;
                 }

--- a/plugin/gnome/NetworkManagerGnomeProxy.cpp
+++ b/plugin/gnome/NetworkManagerGnomeProxy.cpp
@@ -890,8 +890,9 @@ namespace WPEFramework
 
             if(ssid.ssid.empty())
             {
-                NMLOG_WARNING("ssid is empty activating last connected ssid !");
-	        if(_instance != NULL && wifi->activateKnownConnection(nmUtils::wlanIface(), _instance->getLastConnectedSSID()))
+                const string lastConnectedSSID = _instance->getLastConnectedSSID();
+                NMLOG_WARNING("ssid is empty activating last connected ssid (%s) !", lastConnectedSSID.c_str());
+                if(_instance != NULL && wifi->activateKnownConnection(nmUtils::wlanIface(), lastConnectedSSID))
                 {
                     rc = Core::ERROR_NONE;
                 }

--- a/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusClient.cpp
@@ -979,8 +979,9 @@ namespace WPEFramework
                     // Wait for 1 sec to change the device state
                     sleep(1);
                     if(interface == GnomeUtils::getWifiIfname() && _instance != nullptr) {
-                        NMLOG_INFO("Activating connection '%s' ...", _instance->m_lastConnectedSSID.c_str());
-                        activateKnownConnection(GnomeUtils::getWifiIfname(), _instance->m_lastConnectedSSID);
+                        const std::string lastConnectedSSID = _instance->getLastConnectedSSID();
+                        NMLOG_INFO("Activating connection '%s' ...", lastConnectedSSID.c_str());
+                        activateKnownConnection(GnomeUtils::getWifiIfname(), lastConnectedSSID);
                     }
                     else if(interface == GnomeUtils::getEthIfname()) {
                         NMLOG_INFO("Activating connection 'Wired connection 1' ...");

--- a/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
@@ -286,11 +286,11 @@ namespace WPEFramework
 
             if(ssid.ssid.empty() && _instance != NULL)
             {
-                NMLOG_WARNING("ssid is empty activating last connected ssid !");
                 const string lastConnectedSSID = _instance->getLastConnectedSSID();
+                NMLOG_WARNING("ssid is empty activating last connected ssid (%s) !", lastConnectedSSID.c_str());
                 if(_nmGdbusClient->activateKnownConnection(GnomeUtils::getWifiIfname(), lastConnectedSSID))
                     rc = Core::ERROR_NONE;
-	    }
+            }
             else if(ssid.ssid.size() <= 32)
             {
                 if(_nmGdbusClient->wifiConnect(ssid))

--- a/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
+++ b/plugin/gnome/gdbus/NetworkManagerGdbusProxy.cpp
@@ -287,9 +287,10 @@ namespace WPEFramework
             if(ssid.ssid.empty() && _instance != NULL)
             {
                 NMLOG_WARNING("ssid is empty activating last connected ssid !");
-                if(_nmGdbusClient->activateKnownConnection(GnomeUtils::getWifiIfname(), _instance->m_lastConnectedSSID))
+                const string lastConnectedSSID = _instance->getLastConnectedSSID();
+                if(_nmGdbusClient->activateKnownConnection(GnomeUtils::getWifiIfname(), lastConnectedSSID))
                     rc = Core::ERROR_NONE;
-            }
+	    }
             else if(ssid.ssid.size() <= 32)
             {
                 if(_nmGdbusClient->wifiConnect(ssid))


### PR DESCRIPTION
Reason for change: Use mutex to access m_lastConnectedSSID in NetworkManager Plugin.
Priority: P2
Test Procedure: Refer ticket
Risks: Low

Signed-off-by: Mehavarshni_Palaniswamy@comcast.com